### PR TITLE
UI improvements: clickable links, background color, and mobile search

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 :root {
-  --background: #F8F7F5;
+  --background: #fafaf2;
   --foreground: #191919;
 }
 

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -1,0 +1,53 @@
+import { notFound } from "next/navigation";
+import { getPostsByTag, getAllTags } from "@/lib/content";
+import PostGrid from "@/components/PostGrid";
+import type { Metadata } from "next";
+
+interface TagPageProps {
+  params: Promise<{
+    tag: string;
+  }>;
+}
+
+export async function generateStaticParams() {
+  const tags = getAllTags();
+  return tags.map((tag) => ({
+    tag: tag.toLowerCase().replace(/\s+/g, "-"),
+  }));
+}
+
+export async function generateMetadata({
+  params,
+}: TagPageProps): Promise<Metadata> {
+  const { tag } = await params;
+  const tagName = tag.replace(/-/g, " ");
+
+  return {
+    title: `Posts tagged "${tagName}"`,
+    description: `Browse all posts tagged with ${tagName}`,
+  };
+}
+
+export default async function TagPage({ params }: TagPageProps) {
+  const { tag } = await params;
+  const tagName = tag.replace(/-/g, " ");
+  const posts = getPostsByTag(tagName);
+
+  if (posts.length === 0) {
+    notFound();
+  }
+
+  return (
+    <>
+      <div className="max-w-wide mx-auto px-6 pt-12 pb-6">
+        <h1 className="text-4xl md:text-5xl font-serif font-semibold text-charcoal mb-4">
+          Posts tagged &ldquo;{tagName}&rdquo;
+        </h1>
+        <p className="text-lg text-gray">
+          {posts.length} {posts.length === 1 ? "post" : "posts"}
+        </p>
+      </div>
+      <PostGrid posts={posts} />
+    </>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -84,6 +84,7 @@ export default function Header() {
       <MobileMenu
         isOpen={isMobileMenuOpen}
         onClose={() => setIsMobileMenuOpen(false)}
+        onSearchOpen={() => setIsSearchOpen(true)}
       />
 
       {/* Search Modal */}

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -7,9 +7,10 @@ import { useState } from "react";
 interface MobileMenuProps {
   isOpen: boolean;
   onClose: () => void;
+  onSearchOpen: () => void;
 }
 
-export default function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
+export default function MobileMenu({ isOpen, onClose, onSearchOpen }: MobileMenuProps) {
   const [topicsExpanded, setTopicsExpanded] = useState(false);
 
   return (
@@ -104,6 +105,30 @@ export default function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
             >
               Sketches
             </Link>
+
+            <button
+              onClick={() => {
+                onClose();
+                onSearchOpen();
+              }}
+              className="w-full flex items-center gap-3 px-4 py-3 text-lg text-charcoal hover:bg-charcoal/5 rounded-lg transition-colors text-left"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="w-5 h-5"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+                />
+              </svg>
+              Search
+            </button>
           </nav>
         </DialogPanel>
       </div>

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -39,9 +39,12 @@ export default function PostCard({ post, featured = false }: PostCardProps) {
         <div>
           {/* Category Tag */}
           <div className="mb-2">
-            <span className="inline-block px-3 py-1 text-xs font-semibold tracking-wide uppercase bg-charcoal text-cream rounded-full">
+            <Link
+              href={`/topics/${post.category.toLowerCase()}`}
+              className="inline-block px-3 py-1 text-xs font-semibold tracking-wide uppercase bg-charcoal text-cream rounded-full no-underline hover:bg-charcoal/80 transition-colors"
+            >
               {post.category}
-            </span>
+            </Link>
           </div>
 
           {/* Title */}
@@ -71,12 +74,13 @@ export default function PostCard({ post, featured = false }: PostCardProps) {
           {post.tags && post.tags.length > 0 && (
             <div className="mt-4 flex flex-wrap gap-2">
               {post.tags.slice(0, 3).map((tag) => (
-                <span
+                <Link
                   key={tag}
-                  className="text-xs text-gray border border-gray/30 rounded px-2 py-1"
+                  href={`/tags/${tag.toLowerCase().replace(/\s+/g, "-")}`}
+                  className="text-xs text-gray border border-gray/30 rounded px-2 py-1 no-underline hover:border-gray hover:bg-gray/10 transition-colors"
                 >
                   {tag}
-                </span>
+                </Link>
               ))}
             </div>
           )}

--- a/components/PostLayout.tsx
+++ b/components/PostLayout.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { format } from "date-fns";
 import type { Post } from "@/lib/content";
 
@@ -15,9 +16,12 @@ export default function PostLayout({ post, children }: PostLayoutProps) {
       <header className="mb-12">
         {/* Category */}
         <div className="mb-4">
-          <span className="inline-block px-3 py-1 text-xs font-semibold tracking-wide uppercase bg-charcoal text-cream rounded-full">
+          <Link
+            href={`/topics/${post.category.toLowerCase()}`}
+            className="inline-block px-3 py-1 text-xs font-semibold tracking-wide uppercase bg-charcoal text-cream rounded-full no-underline hover:bg-charcoal/80 transition-colors"
+          >
             {post.category}
-          </span>
+          </Link>
         </div>
 
         {/* Title */}
@@ -33,12 +37,13 @@ export default function PostLayout({ post, children }: PostLayoutProps) {
               <span>·</span>
               <div className="flex flex-wrap gap-2">
                 {post.tags.map((tag) => (
-                  <span
+                  <Link
                     key={tag}
-                    className="text-xs border border-gray/30 rounded px-2 py-1"
+                    href={`/tags/${tag.toLowerCase().replace(/\s+/g, "-")}`}
+                    className="text-xs text-gray border border-gray/30 rounded px-2 py-1 no-underline hover:border-gray hover:bg-gray/10 transition-colors"
                   >
                     {tag}
-                  </span>
+                  </Link>
                 ))}
               </div>
             </>

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -117,3 +117,10 @@ export function getAllTags(): string[] {
   const tags = new Set(posts.flatMap((post) => post.tags));
   return Array.from(tags);
 }
+
+export function getPostsByTag(tag: string): Post[] {
+  const posts = getSortedPosts();
+  return posts.filter((post) =>
+    post.tags.some((t) => t.toLowerCase() === tag.toLowerCase())
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,7 +10,7 @@ export default {
   theme: {
     extend: {
       colors: {
-        cream: "#F8F7F5",
+        cream: "#fafaf2",
         charcoal: "#191919",
         gray: "#5F5F5F",
         accent: "#F5B684",


### PR DESCRIPTION
## Summary
- Update background color to match current site (#fafaf2)
- Make category and tag badges clickable throughout the site
- Add search functionality to mobile menu
- Implement clean tag URLs with dedicated `/tags/[tag]` route

## Changes
- **Background color**: Updated from #F8F7F5 to #fafaf2 to match micahwalter.com
- **Clickable categories**: Category badges now link to `/topics/[category]` pages
- **Clickable tags**: Tag badges now use clean URLs `/tags/[tag]` instead of query strings
- **Mobile search**: Added search button to mobile navigation menu
- **New route**: Created `/tags/[tag]` page for tag-based post filtering
- **Content utilities**: Added `getPostsByTag()` helper function

## Test plan
- [x] Build completes successfully
- [x] Category badges link correctly from post cards and post pages
- [x] Tag badges link to dedicated tag pages with clean URLs
- [x] Mobile menu displays search button and opens search modal
- [x] Background color matches current site
- [x] All links have proper hover states

🤖 Generated with [Claude Code](https://claude.com/claude-code)