### PR TITLE
Add image zoom functionality for blog post images

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -114,3 +114,32 @@ pre .hljs-deletion {
     text-wrap: balance;
   }
 }
+
+/* Image zoom animations */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes zoomIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.animate-fadeIn {
+  animation: fadeIn 0.2s ease-out;
+}
+
+.animate-zoomIn {
+  animation: zoomIn 0.3s ease-out;
+}

--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -1,4 +1,5 @@
 import type { MDXComponents } from "mdx/types";
+import ZoomableImage from "./ZoomableImage";
 
 export const mdxComponents: MDXComponents = {
   h1: ({ children }) => (
@@ -69,11 +70,10 @@ export const mdxComponents: MDXComponents = {
     </pre>
   ),
   img: ({ src, alt }) => (
-    <img
+    <ZoomableImage
       src={src}
       alt={alt}
       className="rounded-lg my-8 w-full"
-      loading="lazy"
     />
   ),
   hr: () => <hr className="my-12 border-gray/20" />,

--- a/components/PostLayout.tsx
+++ b/components/PostLayout.tsx
@@ -72,6 +72,7 @@ export default function PostLayout({ post, children }: PostLayoutProps) {
             className="rounded-lg"
             priority={true}
             sizes="(max-width: 768px) 100vw, 645px"
+            zoomable={true}
           />
         </div>
       )}

--- a/components/ResponsiveImage.tsx
+++ b/components/ResponsiveImage.tsx
@@ -9,16 +9,20 @@
  * - Responsive sizing (400px, 800px, 1200px)
  * - Lazy loading
  * - SEO-friendly alt text
+ * - Optional zoom on click (desktop only)
  *
  * Usage:
  *   <ResponsiveImage
  *     src="/images/posts/slug/cover"
  *     alt="Cover image description"
  *     sizes="(max-width: 768px) 100vw, (max-width: 1200px) 800px, 1200px"
+ *     zoomable={true}
  *   />
  */
 
-import React from 'react';
+"use client";
+
+import React, { useState, useEffect, useCallback } from 'react';
 
 interface ResponsiveImageProps {
   /** Base path to image without extension or size suffix (e.g., "/images/posts/slug/cover") */
@@ -35,6 +39,8 @@ interface ResponsiveImageProps {
   width?: number;
   /** Height for aspect ratio calculation (optional) */
   height?: number;
+  /** Enable zoom on click (desktop only, defaults to false) */
+  zoomable?: boolean;
 }
 
 const SIZES = [400, 800, 1200];
@@ -63,43 +69,129 @@ export default function ResponsiveImage({
   priority = false,
   width,
   height,
+  zoomable = false,
 }: ResponsiveImageProps) {
+  const [isZoomed, setIsZoomed] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+
+  // Detect mobile on mount and window resize
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+    return () => window.removeEventListener("resize", checkMobile);
+  }, []);
+
+  // Handle ESC key to close zoom
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isZoomed) {
+        setIsZoomed(false);
+      }
+    };
+
+    if (isZoomed) {
+      document.addEventListener("keydown", handleEscape);
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "";
+    };
+  }, [isZoomed]);
+
+  const handleClick = useCallback(() => {
+    if (zoomable && !isMobile) {
+      setIsZoomed(!isZoomed);
+    }
+  }, [zoomable, isMobile, isZoomed]);
+
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        setIsZoomed(false);
+      }
+    },
+    []
+  );
+
   // Generate srcsets for WebP and JPEG
   const webpSrcSet = generateSrcSet(src, 'webp');
   const jpegSrcSet = generateSrcSet(src, 'jpg');
 
-  // Fallback src (800px JPEG)
+  // Fallback src (1200px JPEG for zoom, 800px for normal)
   const fallbackSrc = `${CDN_BASE}${src}-800.jpg`;
+  const zoomedSrc = `${CDN_BASE}${src}-1200.jpg`;
 
   // Calculate aspect ratio for placeholder if dimensions provided
   const aspectRatio = width && height ? (height / width) * 100 : undefined;
 
+  const pictureClassName = zoomable && !isMobile
+    ? `${className} cursor-zoom-in hover:opacity-90 transition-opacity`
+    : className;
+
   return (
-    <picture className={className}>
-      {/* WebP source (preferred, smaller file size) */}
-      <source srcSet={webpSrcSet} type="image/webp" sizes={sizes} />
+    <>
+      <picture className={pictureClassName} onClick={handleClick}>
+        {/* WebP source (preferred, smaller file size) */}
+        <source srcSet={webpSrcSet} type="image/webp" sizes={sizes} />
 
-      {/* JPEG source (fallback for older browsers) */}
-      <source srcSet={jpegSrcSet} type="image/jpeg" sizes={sizes} />
+        {/* JPEG source (fallback for older browsers) */}
+        <source srcSet={jpegSrcSet} type="image/jpeg" sizes={sizes} />
 
-      {/* Fallback img element */}
-      <img
-        src={fallbackSrc}
-        alt={alt}
-        loading={priority ? 'eager' : 'lazy'}
-        decoding="async"
-        style={
-          aspectRatio
-            ? {
-                aspectRatio: `${width} / ${height}`,
-                width: '100%',
-                height: 'auto',
-              }
-            : { width: '100%', height: 'auto' }
-        }
-        className="object-cover"
-      />
-    </picture>
+        {/* Fallback img element */}
+        <img
+          src={fallbackSrc}
+          alt={alt}
+          loading={priority ? 'eager' : 'lazy'}
+          decoding="async"
+          style={
+            aspectRatio
+              ? {
+                  aspectRatio: `${width} / ${height}`,
+                  width: '100%',
+                  height: 'auto',
+                }
+              : { width: '100%', height: 'auto' }
+          }
+          className="object-cover"
+        />
+      </picture>
+
+      {/* Zoom overlay */}
+      {isZoomed && zoomable && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-charcoal/95 cursor-zoom-out animate-fadeIn"
+          onClick={handleOverlayClick}
+        >
+          <div className="relative max-w-[95vw] max-h-[95vh] p-4">
+            <picture>
+              <source srcSet={webpSrcSet} type="image/webp" sizes="95vw" />
+              <source srcSet={jpegSrcSet} type="image/jpeg" sizes="95vw" />
+              <img
+                src={zoomedSrc}
+                alt={alt}
+                className="max-w-full max-h-[95vh] object-contain rounded-lg shadow-2xl animate-zoomIn"
+                onClick={() => setIsZoomed(false)}
+              />
+            </picture>
+
+            {/* Close button */}
+            <button
+              onClick={() => setIsZoomed(false)}
+              className="absolute top-8 right-8 text-cream hover:text-accent transition-colors text-4xl font-light leading-none"
+              aria-label="Close zoom"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/components/ZoomableImage.tsx
+++ b/components/ZoomableImage.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface ZoomableImageProps {
+  src?: string;
+  alt?: string;
+  className?: string;
+}
+
+export default function ZoomableImage({
+  src,
+  alt,
+  className = "",
+}: ZoomableImageProps) {
+  const [isZoomed, setIsZoomed] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+
+  // Detect mobile on mount and window resize
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+    return () => window.removeEventListener("resize", checkMobile);
+  }, []);
+
+  // Handle ESC key to close zoom
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isZoomed) {
+        setIsZoomed(false);
+      }
+    };
+
+    if (isZoomed) {
+      document.addEventListener("keydown", handleEscape);
+      // Prevent scrolling when zoomed
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "";
+    };
+  }, [isZoomed]);
+
+  const handleClick = useCallback(() => {
+    // Only enable zoom on desktop
+    if (!isMobile) {
+      setIsZoomed(!isZoomed);
+    }
+  }, [isMobile, isZoomed]);
+
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      // Close if clicking the overlay (not the image)
+      if (e.target === e.currentTarget) {
+        setIsZoomed(false);
+      }
+    },
+    []
+  );
+
+  if (!src) return null;
+
+  return (
+    <>
+      {/* Original image with click handler */}
+      <img
+        src={src}
+        alt={alt}
+        className={`${className} ${!isMobile ? "cursor-zoom-in hover:opacity-90 transition-opacity" : ""}`}
+        onClick={handleClick}
+        loading="lazy"
+      />
+
+      {/* Zoom overlay (only rendered when zoomed) */}
+      {isZoomed && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-charcoal/95 cursor-zoom-out animate-fadeIn"
+          onClick={handleOverlayClick}
+        >
+          <div className="relative max-w-[95vw] max-h-[95vh] p-4">
+            <img
+              src={src}
+              alt={alt}
+              className="max-w-full max-h-[95vh] object-contain rounded-lg shadow-2xl animate-zoomIn"
+              onClick={() => setIsZoomed(false)}
+            />
+
+            {/* Close button */}
+            <button
+              onClick={() => setIsZoomed(false)}
+              className="absolute top-8 right-8 text-cream hover:text-accent transition-colors text-4xl font-light leading-none"
+              aria-label="Close zoom"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Implements click-to-zoom functionality for both cover images and inline MDX images with smooth animations.

**Key Features:**
- Click any image to zoom to full viewport size (95% of window)
- Desktop-only feature (automatically disabled on mobile < 768px)
- Multiple ways to close: click image, click outside, press ESC, or use close button
- Smooth fade-in overlay and zoom-in animations
- Prevents body scroll when zoomed
- Visual hover feedback (cursor changes, slight opacity change)

**Technical Changes:**
- Created `ZoomableImage` component for MDX inline images
- Enhanced `ResponsiveImage` component with optional `zoomable` prop
- Added CSS keyframe animations (fadeIn, zoomIn)
- Enabled zoom on cover images in PostLayout
- Mobile detection with window resize listener

## Test Plan

- [x] Test cover image zoom on desktop (click to zoom, ESC/click to close)
- [x] Test on mobile (< 768px) - zoom should be disabled
- [x] Verify smooth animations
- [x] Check that body scroll is prevented when zoomed
- [x] Test multiple close methods (click, ESC, close button)
- [x] Verify cursor changes on hover (desktop)
- [x] Test in production build
- [x] Verify across different browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)