### PR TITLE
Add GitHub Actions workflow for newsletter Lambda auto-deploy

### DIFF
--- a/.github/workflows/newsletter-deploy.yml
+++ b/.github/workflows/newsletter-deploy.yml
@@ -1,0 +1,104 @@
+name: Deploy Newsletter Lambda Stack
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'infra/newsletter-lambdas/**'
+      - 'infra/newsletter.yml'
+      - '.github/workflows/newsletter-deploy.yml'
+
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  ARTIFACTS_BUCKET: micahwalter-newsletter-artifacts
+  ARTIFACTS_PREFIX: newsletter/lambda
+  STACK_NAME: micahwalter-newsletter
+  FUNCTIONS: subscribe confirm unsubscribe email dispatch
+
+jobs:
+  deploy:
+    name: Build and deploy newsletter Lambda stack
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need previous commit to detect changed files
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: infra/newsletter-lambdas/go.mod
+          cache-dependency-path: infra/newsletter-lambdas/go.sum
+
+      - name: Detect what changed
+        id: changed
+        run: |
+          if git diff --name-only HEAD~1 HEAD | grep -q '^infra/newsletter\.yml$'; then
+            echo "template_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "template_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build Lambda functions
+        working-directory: infra/newsletter-lambdas
+        run: make build
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload Lambda zips to S3
+        working-directory: infra/newsletter-lambdas
+        run: |
+          for fn in ${{ env.FUNCTIONS }}; do
+            echo "  uploading ${fn}.zip..."
+            aws s3 cp dist/${fn}.zip \
+              s3://${{ env.ARTIFACTS_BUCKET }}/${{ env.ARTIFACTS_PREFIX }}/${fn}.zip \
+              --region ${{ env.AWS_REGION }}
+          done
+
+      - name: Deploy via CloudFormation (template changed)
+        if: steps.changed.outputs.template_changed == 'true'
+        run: |
+          aws cloudformation deploy \
+            --stack-name ${{ env.STACK_NAME }} \
+            --template-file infra/newsletter.yml \
+            --region ${{ env.AWS_REGION }} \
+            --capabilities CAPABILITY_NAMED_IAM \
+            --parameter-overrides \
+              LambdaArtifactsBucket=${{ env.ARTIFACTS_BUCKET }} \
+              LambdaArtifactsKeyPrefix=${{ env.ARTIFACTS_PREFIX }}
+
+      - name: Update function code only (Go source changed)
+        if: steps.changed.outputs.template_changed == 'false'
+        run: |
+          for fn in ${{ env.FUNCTIONS }}; do
+            echo "  updating newsletter-${fn}..."
+            aws lambda update-function-code \
+              --function-name newsletter-${fn} \
+              --s3-bucket ${{ env.ARTIFACTS_BUCKET }} \
+              --s3-key ${{ env.ARTIFACTS_PREFIX }}/${fn}.zip \
+              --region ${{ env.AWS_REGION }} \
+              --no-cli-pager
+          done
+
+      - name: Deployment summary
+        run: |
+          echo "Deploy mode: ${{ steps.changed.outputs.template_changed == 'true' && 'CloudFormation stack update' || 'Lambda function code update' }}"
+          echo ""
+          echo "Functions deployed:"
+          for fn in ${{ env.FUNCTIONS }}; do
+            size=$(stat -c%s infra/newsletter-lambdas/dist/${fn}.zip 2>/dev/null || echo "?")
+            echo "  newsletter-${fn}  (${size} bytes)"
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,7 +304,12 @@ Test sends (`--test <email>`) skip steps 2, 3, and 6 entirely — no subscriber 
 
 ### Lambda infrastructure deploy
 
-Only needed when `infra/newsletter.yml` or Go Lambda code changes. The frontend deploys automatically via GitHub Actions on push to main.
+Newsletter Lambda changes deploy **automatically** via GitHub Actions (`.github/workflows/newsletter-deploy.yml`) on push to `main` when files change under `infra/newsletter-lambdas/**` or `infra/newsletter.yml`.
+
+- **Go source only changed** → fast path: build + upload zips + `aws lambda update-function-code` (~1 min)
+- **`infra/newsletter.yml` changed** → full path: build + upload zips + `aws cloudformation deploy` (~3-4 min)
+
+Manual local deploy (if needed):
 
 ```bash
 cd infra/newsletter-lambdas
@@ -322,6 +327,16 @@ AWS_PROFILE=www aws cloudformation deploy \
 
 # Lambda code only (faster):
 make update-functions
+```
+
+After updating `infra/github-actions-role.yml`, redeploy the IAM stack:
+
+```bash
+AWS_PROFILE=www aws cloudformation deploy \
+  --stack-name micahwalter-github-actions-role \
+  --template-file infra/github-actions-role.yml \
+  --region us-east-1 \
+  --capabilities CAPABILITY_NAMED_IAM
 ```
 
 ### Key files

--- a/infra/github-actions-role.yml
+++ b/infra/github-actions-role.yml
@@ -85,6 +85,39 @@ Resources:
                   - cloudfront:GetInvalidation
                 Resource:
                   - !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistributionId}'
+              # S3 — upload Lambda artifacts for newsletter stack
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:ListBucket
+                Resource:
+                  - arn:aws:s3:::micahwalter-newsletter-artifacts
+                  - arn:aws:s3:::micahwalter-newsletter-artifacts/*
+              # Lambda — update function code (fast path, no CF needed)
+              - Effect: Allow
+                Action:
+                  - lambda:UpdateFunctionCode
+                  - lambda:GetFunction
+                Resource:
+                  - !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:newsletter-*'
+              # CloudFormation — deploy newsletter stack
+              - Effect: Allow
+                Action:
+                  - cloudformation:DescribeStacks
+                  - cloudformation:CreateChangeSet
+                  - cloudformation:ExecuteChangeSet
+                  - cloudformation:DescribeChangeSet
+                  - cloudformation:DeleteChangeSet
+                  - cloudformation:GetTemplate
+                Resource:
+                  - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/micahwalter-newsletter/*'
+              # IAM PassRole — required for CloudFormation to assign Lambda execution roles
+              - Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource:
+                  - !Sub 'arn:aws:iam::${AWS::AccountId}:role/newsletter-*-fn-role'
       Tags:
         - Key: Project
           Value: micahwalter-www


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/newsletter-deploy.yml` — triggers on push to `main` when `infra/newsletter-lambdas/**` or `infra/newsletter.yml` change, plus `workflow_dispatch` for manual runs
- Smart deploy strategy: if only Go source changed → fast `lambda:UpdateFunctionCode` (~1 min); if `newsletter.yml` changed → full `cloudformation deploy` (~3-4 min)
- Updates `infra/github-actions-role.yml` with four new IAM statements: S3 artifact uploads, Lambda `UpdateFunctionCode`/`GetFunction`, CloudFormation newsletter stack operations, and `iam:PassRole` for newsletter function roles

## Test plan

- [ ] Verify workflow file syntax is valid (GitHub Actions lint)
- [ ] Merge a Go-only change and confirm fast path runs (`lambda:UpdateFunctionCode`, no CloudFormation)
- [ ] Merge a `newsletter.yml` change and confirm full CloudFormation deploy path runs
- [ ] Update `infra/github-actions-role.yml` stack in AWS before first CI run: `AWS_PROFILE=www aws cloudformation deploy --stack-name micahwalter-github-actions-role --template-file infra/github-actions-role.yml --region us-east-1 --capabilities CAPABILITY_NAMED_IAM`
- [ ] Confirm deployment summary step prints function names and zip sizes

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)