### PR TITLE
Add api.micahwalter.com custom domain for newsletter API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,6 +329,10 @@ AWS_PROFILE=www aws cloudformation deploy \
 make update-functions
 ```
 
+After the first deploy that adds the custom domain, update the GitHub Actions secret
+`NEXT_PUBLIC_NEWSLETTER_API_URL` → `https://api.micahwalter.com`, then trigger a
+site redeploy so the URL is baked into the static build.
+
 After updating `infra/github-actions-role.yml`, redeploy the IAM stack:
 
 ```bash

--- a/infra/newsletter.yml
+++ b/infra/newsletter.yml
@@ -47,6 +47,11 @@ Parameters:
       Set to false if micahwalter.com is already verified in SES and you do
       not want CloudFormation to take ownership of the identity.
 
+  ApiSubdomain:
+    Type: String
+    Default: api.micahwalter.com
+    Description: Custom domain name for the newsletter API (must be under DomainName)
+
 # ---------------------------------------------------------------------------
 # Conditions
 # ---------------------------------------------------------------------------
@@ -259,6 +264,75 @@ Resources:
         Environment: Production
         Application: NewsletterSubscription
         ManagedBy: CloudFormation
+
+  # -------------------------------------------------------------------------
+  # Custom domain — api.micahwalter.com
+  # -------------------------------------------------------------------------
+
+  ApiCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Ref ApiSubdomain
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: !Ref ApiSubdomain
+          HostedZoneId: !Ref HostedZoneId
+      Tags:
+        - Key: Project
+          Value: micahwalter-newsletter
+        - Key: Environment
+          Value: Production
+        - Key: Application
+          Value: NewsletterSubscription
+        - Key: ManagedBy
+          Value: CloudFormation
+
+  ApiDomainName:
+    Type: AWS::ApiGatewayV2::DomainName
+    DependsOn: ApiCertificate
+    Properties:
+      DomainName: !Ref ApiSubdomain
+      DomainNameConfigurations:
+        - CertificateArn: !Ref ApiCertificate
+          EndpointType: REGIONAL
+          SecurityPolicy: TLS_1_2
+      Tags:
+        Project: micahwalter-newsletter
+        Environment: Production
+        Application: NewsletterSubscription
+        ManagedBy: CloudFormation
+
+  ApiMapping:
+    Type: AWS::ApiGatewayV2::ApiMapping
+    DependsOn: ApiDomainName
+    Properties:
+      ApiId: !Ref NewsletterApi
+      DomainName: !Ref ApiSubdomain
+      Stage: !Ref NewsletterApiStage
+
+  ApiDomainARecord:
+    Type: AWS::Route53::RecordSet
+    DependsOn: ApiDomainName
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Ref ApiSubdomain
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt ApiDomainName.RegionalDomainName
+        HostedZoneId: !GetAtt ApiDomainName.RegionalHostedZoneId
+        EvaluateTargetHealth: false
+
+  ApiDomainAAAARecord:
+    Type: AWS::Route53::RecordSet
+    DependsOn: ApiDomainName
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Ref ApiSubdomain
+      Type: AAAA
+      AliasTarget:
+        DNSName: !GetAtt ApiDomainName.RegionalDomainName
+        HostedZoneId: !GetAtt ApiDomainName.RegionalHostedZoneId
+        EvaluateTargetHealth: false
 
   # -------------------------------------------------------------------------
   # IAM Roles — one per Lambda, least-privilege
@@ -1222,11 +1296,19 @@ Outputs:
 
   ApiEndpoint:
     Description: >
-      Newsletter API base URL. Set as NEXT_PUBLIC_NEWSLETTER_API_URL in the
-      Next.js environment. Routes: POST /subscribe, /confirm, /unsubscribe.
+      Auto-generated API Gateway URL (kept for reference). Prefer ApiCustomDomainUrl.
     Value: !Sub https://${NewsletterApi}.execute-api.${AWS::Region}.amazonaws.com
     Export:
       Name: micahwalter-newsletter-api-endpoint
+
+  ApiCustomDomainUrl:
+    Description: >
+      Stable custom-domain URL for the newsletter API. Set as
+      NEXT_PUBLIC_NEWSLETTER_API_URL in GitHub Actions secrets and .env.local.
+      Routes: POST /subscribe, /confirm, /unsubscribe.
+    Value: !Sub https://${ApiSubdomain}
+    Export:
+      Name: micahwalter-newsletter-api-custom-url
 
   TableName:
     Description: DynamoDB table name


### PR DESCRIPTION
## Summary

- Adds an ACM certificate (DNS-validated via Route53) for `api.micahwalter.com`
- Creates an `AWS::ApiGatewayV2::DomainName` backed by that cert
- Maps the existing `NewsletterApi` / `$default` stage to the custom domain via `AWS::ApiGatewayV2::ApiMapping`
- Adds Route53 A + AAAA alias records pointing at the API Gateway regional endpoint
- Adds a stable `ApiCustomDomainUrl` CloudFormation output (`https://api.micahwalter.com`)
- Updates CLAUDE.md with post-deploy instructions for updating the GitHub Actions secret

Closes #25

## After merging + deploying

1. The auto-deploy workflow will run `aws cloudformation deploy` (infra/newsletter.yml changed)
2. Once the stack is `UPDATE_COMPLETE`, update the GitHub Actions secret:
   - `NEXT_PUBLIC_NEWSLETTER_API_URL` → `https://api.micahwalter.com`
3. Trigger a site redeploy to bake the new URL into the static build
4. Smoke-test: `curl -s -o /dev/null -w "%{http_code}" -X POST https://api.micahwalter.com/subscribe -H 'Content-Type: application/json' -d '{"email":"test@example.com","name":"Test"}'`

## Test plan

- [ ] Stack deploys without errors (`UPDATE_COMPLETE`)
- [ ] ACM cert reaches `ISSUED` status (DNS validation may take a few minutes)
- [ ] `https://api.micahwalter.com/subscribe` returns expected response
- [ ] Old execute-api URL still works (additive change, nothing removed)
- [ ] CORS still allows requests from `https://www.micahwalter.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)