### PR TITLE
Scope newsletter API to /newsletter base path

### DIFF
--- a/infra/newsletter.yml
+++ b/infra/newsletter.yml
@@ -278,6 +278,7 @@ Resources:
       ApiId: !Ref NewsletterApi
       DomainName: !Ref ApiDomainName
       Stage: !Ref NewsletterApiStage
+      ApiMappingKey: newsletter
 
   # -------------------------------------------------------------------------
   # IAM Roles — one per Lambda, least-privilege


### PR DESCRIPTION
## Summary

- Adds `ApiMappingKey: newsletter` to `NewsletterApiMapping` in `infra/newsletter.yml`
- Newsletter routes move from `api.micahwalter.com/*` → `api.micahwalter.com/newsletter/*`
- API GW V2 strips the base path before forwarding, so Lambda routes are unaffected
- Frees the domain root for future APIs to claim their own base paths

Closes #27

## Deploy steps (after merge)

These need to happen together to avoid a broken subscribe form:

1. Stack auto-deploys via `newsletter-deploy.yml` (~3-4 min)
2. Update GitHub Actions secret: `NEXT_PUBLIC_NEWSLETTER_API_URL` → `https://api.micahwalter.com/newsletter`
3. Trigger site redeploy: `gh workflow run deploy.yml --ref main`

## Test plan

- [ ] `POST https://api.micahwalter.com/newsletter/subscribe` returns `202`
- [ ] `POST https://api.micahwalter.com/subscribe` returns `404` (root no longer mapped)
- [ ] Subscribe form on live site works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)