### PR TITLE
Add missing tags to all AWS CloudFormation resources

### DIFF
--- a/infra/api-domain.yml
+++ b/infra/api-domain.yml
@@ -40,6 +40,8 @@ Resources:
           Value: micahwalter-www
         - Key: Environment
           Value: Production
+        - Key: Application
+          Value: StaticWebsite
         - Key: ManagedBy
           Value: CloudFormation
 
@@ -56,6 +58,7 @@ Resources:
       Tags:
         Project: micahwalter-www
         Environment: Production
+        Application: StaticWebsite
         ManagedBy: CloudFormation
 
   # Route53 alias records — A and AAAA

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -140,6 +140,10 @@ Resources:
       Tags:
         - Key: Project
           Value: micahwalter-www
+        - Key: Environment
+          Value: Production
+        - Key: Application
+          Value: StaticWebsite
         - Key: ManagedBy
           Value: CloudFormation
 
@@ -295,6 +299,8 @@ Resources:
           Value: StaticWebsite
         - Key: ManagedBy
           Value: CloudFormation
+        - Key: Purpose
+          Value: MainDistribution
 
   # Apex redirect CloudFront Distribution (micahwalter.com → www.micahwalter.com)
   # The CloudFront Function returns a 301 redirect on every request; the origin is never hit.
@@ -342,6 +348,8 @@ Resources:
           Value: StaticWebsite
         - Key: ManagedBy
           Value: CloudFormation
+        - Key: Purpose
+          Value: ApexRedirect
 
   # Bucket Policy for Website Bucket
   WebsiteBucketPolicy:

--- a/infra/newsletter.yml
+++ b/infra/newsletter.yml
@@ -230,6 +230,15 @@ Resources:
       Targets:
         - Id: email-send-queue
           Arn: !GetAtt EmailSendQueue.Arn
+      Tags:
+        - Key: Project
+          Value: micahwalter-newsletter
+        - Key: Environment
+          Value: Production
+        - Key: Application
+          Value: NewsletterSubscription
+        - Key: ManagedBy
+          Value: CloudFormation
 
   # -------------------------------------------------------------------------
   # API Gateway — HTTP API with CORS
@@ -665,6 +674,15 @@ Resources:
         NextSigningKeyLength: RSA_2048_BIT
       FeedbackAttributes:
         EmailForwardingEnabled: true
+      Tags:
+        - Key: Project
+          Value: micahwalter-newsletter
+        - Key: Environment
+          Value: Production
+        - Key: Application
+          Value: NewsletterSubscription
+        - Key: ManagedBy
+          Value: CloudFormation
 
   # DKIM CNAME records — tokens are provided by SES via the EmailIdentity resource
   DkimRecord1:
@@ -1074,6 +1092,15 @@ Resources:
       Targets:
         - Id: NewsletterDispatchQueue
           Arn: !GetAtt NewsletterDispatchQueue.Arn
+      Tags:
+        - Key: Project
+          Value: micahwalter-newsletter
+        - Key: Environment
+          Value: Production
+        - Key: Application
+          Value: NewsletterSubscription
+        - Key: ManagedBy
+          Value: CloudFormation
 
   # -------------------------------------------------------------------------
   # Dispatch Lambda — IAM role and function


### PR DESCRIPTION
- infra.yml: Add Environment and Application to ACMCertificate; add
  Purpose (MainDistribution/ApexRedirect) to CloudFront distributions
- api-domain.yml: Add Application tag to ApiCertificate and
  ApiGatewayDomainName for consistency with other micahwalter-www resources
- newsletter.yml: Add standard tags to RouteToEmailRule,
  RouteNewsletterSend, and SESEmailIdentity

Resources that don't support Tags in CloudFormation (OAC, CloudFront
Functions, SQS policies, API GW integrations/routes/mappings, Lambda
permissions/event-source mappings, Route53 record sets) are unchanged.

https://claude.ai/code/session_01EjKRJPTLTyfChDiJCdVoN7