### PR TITLE
Add cover image thumbnails to search results

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -5,6 +5,8 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import type { Post } from "@/lib/content";
 
+const CDN_BASE = process.env.NEXT_PUBLIC_CDN_URL || '';
+
 interface SearchBarProps {
   isOpen: boolean;
   onClose: () => void;
@@ -142,6 +144,16 @@ export default function SearchBar({ isOpen, onClose }: SearchBarProps) {
                           {post.excerpt}
                         </p>
                       </div>
+                      {post.thumbnailUrl && (
+                        <div className="flex-shrink-0 w-16 h-16 rounded overflow-hidden bg-gray/10">
+                          <img
+                            src={`${CDN_BASE}${post.thumbnailUrl}`}
+                            alt=""
+                            className="w-full h-full object-cover"
+                            loading="lazy"
+                          />
+                        </div>
+                      )}
                     </div>
                   </Link>
                 ))}

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -12,6 +12,7 @@ export interface Post {
   category: string;
   tags: string[];
   coverImage?: string;
+  thumbnailUrl?: string; // Resolved 400px WebP path for search results
   draft: boolean;
   content: string;
   type?: 'blog' | 'photo' | 'email'; // Content type (defaults to 'blog')

--- a/scripts/generate-posts-json.js
+++ b/scripts/generate-posts-json.js
@@ -30,6 +30,14 @@ function getAllPosts() {
       const id = data.id ? String(data.id) : undefined;
       const slug = (data.type === 'photo' && id) ? id : folder.replace(/^\d{4}-\d{2}-\d{2}-/, "");
 
+      // Resolve thumbnail URL from cover image (400px WebP variant)
+      const coverFilename = data.coverImage
+        ? data.coverImage.replace(/^\.\//, '').replace(/\.(jpg|jpeg|png)$/i, '')
+        : null;
+      const thumbnailUrl = coverFilename
+        ? `/images/posts/${folder}/${coverFilename}-400.webp`
+        : undefined;
+
       return {
         slug,
         folderName: folder, // Store folder name for image paths
@@ -39,6 +47,7 @@ function getAllPosts() {
         category: data.category || "Writing",
         tags: data.tags || [],
         coverImage: data.coverImage || undefined,
+        thumbnailUrl,
         draft: data.draft || false,
         type: data.type || 'blog',
         // Photo-specific metadata for search


### PR DESCRIPTION
- Add thumbnailUrl field to generate-posts-json.js that resolves the
  400px WebP path (/images/posts/{folder}/{filename}-400.webp) from
  the coverImage frontmatter value
- Add thumbnailUrl to Post interface in lib/content.ts
- Display 64×64 thumbnail in SearchBar results when available,
  positioned to the right of the text with graceful fallback for
  posts without cover images

Closes #17

https://claude.ai/code/session_016ri6TR8UyhNgXmVvnPvrHD