### PR TITLE
Hide Topics and Sketches links from mobile navigation

### DIFF
--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { Dialog, DialogPanel } from "@headlessui/react";
-import { useState } from "react";
 
 interface MobileMenuProps {
   isOpen: boolean;
@@ -11,8 +10,6 @@ interface MobileMenuProps {
 }
 
 export default function MobileMenu({ isOpen, onClose, onSearchOpen }: MobileMenuProps) {
-  const [topicsExpanded, setTopicsExpanded] = useState(false);
-
   return (
     <Dialog open={isOpen} onClose={onClose} className="relative z-50">
       {/* Backdrop */}
@@ -53,65 +50,12 @@ export default function MobileMenu({ isOpen, onClose, onSearchOpen }: MobileMenu
               Home
             </Link>
 
-            {/* Topics Submenu */}
-            <div>
-              <button
-                onClick={() => setTopicsExpanded(!topicsExpanded)}
-                className="w-full flex items-center justify-between px-4 py-3 text-lg text-charcoal hover:bg-charcoal/5 rounded-lg transition-colors"
-              >
-                Topics
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={1.5}
-                  stroke="currentColor"
-                  className={`w-5 h-5 transition-transform ${
-                    topicsExpanded ? "rotate-180" : ""
-                  }`}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="m19.5 8.25-7.5 7.5-7.5-7.5"
-                  />
-                </svg>
-              </button>
-
-              {topicsExpanded && (
-                <div className="ml-4 mt-2 space-y-2">
-                  <Link
-                    href="/topics/ai"
-                    onClick={onClose}
-                    className="block px-4 py-2 text-charcoal no-underline hover:bg-charcoal/5 rounded-lg transition-colors"
-                  >
-                    AI
-                  </Link>
-                  <Link
-                    href="/topics/aws"
-                    onClick={onClose}
-                    className="block px-4 py-2 text-charcoal no-underline hover:bg-charcoal/5 rounded-lg transition-colors"
-                  >
-                    AWS
-                  </Link>
-                </div>
-              )}
-            </div>
-
             <Link
               href="/photos"
               onClick={onClose}
               className="block px-4 py-3 text-lg text-charcoal no-underline hover:bg-charcoal/5 rounded-lg transition-colors"
             >
               Photos
-            </Link>
-
-            <Link
-              href="/sketches"
-              onClick={onClose}
-              className="block px-4 py-3 text-lg text-charcoal no-underline hover:bg-charcoal/5 rounded-lg transition-colors"
-            >
-              Sketches
             </Link>
 
             <Link


### PR DESCRIPTION
Removes the Topics submenu (with AI/AWS sub-links) and Sketches link
from the mobile menu, along with the now-unused topicsExpanded state
and useState import.

https://claude.ai/code/session_012vxcp4AFgj5XLJ7xHvmMhV