### PR TITLE
Use hamburger menu on both desktop and mobile

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -23,15 +23,8 @@ export default function Header() {
               MICAH WALTER
             </Link>
 
-            {/* Desktop Navigation */}
-            <div className="hidden md:flex items-center gap-8">
-              <Link
-                href="/about"
-                className="text-charcoal hover:text-gray transition-colors no-underline text-sm tracking-wide"
-                style={{ fontFamily: 'system-ui, -apple-system, sans-serif' }}
-              >
-                ABOUT
-              </Link>
+            {/* Nav Buttons */}
+            <div className="flex items-center gap-4">
               <button
                 onClick={() => setIsSearchOpen(true)}
                 className="text-charcoal hover:text-gray transition-colors"
@@ -52,33 +45,9 @@ export default function Header() {
                   />
                 </svg>
               </button>
-            </div>
-
-            {/* Mobile Buttons */}
-            <div className="md:hidden flex items-center gap-4">
-              <button
-                onClick={() => setIsSearchOpen(true)}
-                className="text-charcoal"
-                aria-label="Search"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={1.5}
-                  stroke="currentColor"
-                  className="w-5 h-5"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
-                  />
-                </svg>
-              </button>
               <button
                 onClick={() => setIsMobileMenuOpen(true)}
-                className="text-charcoal"
+                className="text-charcoal hover:text-gray transition-colors"
                 aria-label="Open menu"
               >
                 <svg
@@ -101,7 +70,7 @@ export default function Header() {
         </div>
       </header>
 
-      {/* Mobile Menu */}
+      {/* Menu */}
       <MobileMenu
         isOpen={isMobileMenuOpen}
         onClose={() => setIsMobileMenuOpen(false)}


### PR DESCRIPTION
Replaces the desktop inline nav links + separate mobile button group with a single unified set of buttons (search + hamburger) visible at all breakpoints. The slide-out menu now serves as the sole nav on every screen size.

https://claude.ai/code/session_012vxcp4AFgj5XLJ7xHvmMhV