### PR TITLE
Send admin email notification on new subscriber confirmation

### DIFF
--- a/infra/newsletter-lambdas/cmd/email/main.go
+++ b/infra/newsletter-lambdas/cmd/email/main.go
@@ -27,6 +27,7 @@ var (
 	sesClient   *ses.Client
 	senderEmail string
 	siteURL     string
+	adminEmail  string
 )
 
 func init() {
@@ -38,6 +39,7 @@ func init() {
 	sesClient = ses.NewFromConfig(cfg)
 	senderEmail = os.Getenv("SENDER_EMAIL")
 	siteURL = os.Getenv("SITE_URL")
+	adminEmail = os.Getenv("ADMIN_EMAIL")
 }
 
 // eventEnvelope is the EventBridge event structure as delivered via SQS.
@@ -110,7 +112,46 @@ func sendWelcomeEmail(ctx context.Context, raw json.RawMessage) error {
 		"unsubscribe_link": unsubLink,
 	})
 
-	return sendTemplated(ctx, detail.Email, templateWelcome, string(templateData))
+	if err := sendTemplated(ctx, detail.Email, templateWelcome, string(templateData)); err != nil {
+		return err
+	}
+
+	if adminEmail != "" {
+		if err := sendAdminNotification(ctx, detail); err != nil {
+			// Log but don't fail — the subscriber's welcome email was sent successfully.
+			slog.Error("email: failed to send admin notification", "err", err)
+		}
+	}
+
+	return nil
+}
+
+func sendAdminNotification(ctx context.Context, detail evts.SubscriberConfirmedDetail) error {
+	name := detail.Name
+	if name == "" {
+		name = "(no name)"
+	}
+	subject := fmt.Sprintf("New newsletter subscriber: %s", detail.Email)
+	body := fmt.Sprintf("New subscriber confirmed!\n\nName: %s\nEmail: %s\nConfirmed at: %s\n",
+		name, detail.Email, detail.ConfirmedAt)
+
+	_, err := sesClient.SendEmail(ctx, &ses.SendEmailInput{
+		Source: aws.String(senderEmail),
+		Destination: &sestypes.Destination{
+			ToAddresses: []string{adminEmail},
+		},
+		Message: &sestypes.Message{
+			Subject: &sestypes.Content{Data: aws.String(subject)},
+			Body: &sestypes.Body{
+				Text: &sestypes.Content{Data: aws.String(body)},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("SES SendEmail (admin notification): %w", err)
+	}
+	slog.Info("email: admin notification sent", "admin", adminEmail)
+	return nil
 }
 
 func sendGoodbyeEmail(ctx context.Context, raw json.RawMessage) error {

--- a/infra/newsletter.yml
+++ b/infra/newsletter.yml
@@ -39,6 +39,11 @@ Parameters:
     Default: micah@micahwalter.com
     Description: From address for all newsletter emails (must be SES-verified)
 
+  AdminEmail:
+    Type: String
+    Default: micah@micahwalter.com
+    Description: Email address to notify when a new subscriber confirms their subscription
+
   CreateSESIdentity:
     Type: String
     Default: 'true'
@@ -436,7 +441,9 @@ Resources:
                   - sqs:GetQueueAttributes
                 Resource: !GetAtt EmailSendQueue.Arn
               - Effect: Allow
-                Action: ses:SendTemplatedEmail
+                Action:
+                  - ses:SendTemplatedEmail
+                  - ses:SendEmail
                 Resource: '*'
               - Effect: Allow
                 Action: secretsmanager:GetSecretValue
@@ -559,6 +566,7 @@ Resources:
         Variables:
           SENDER_EMAIL: !Ref SenderEmail
           SITE_URL: !Ref SiteUrl
+          ADMIN_EMAIL: !Ref AdminEmail
       Tags:
         - Key: Project
           Value: micahwalter-newsletter


### PR DESCRIPTION
## Summary

- When a subscriber confirms their email, the `newsletter-email` Lambda now sends a plain-text admin notification in addition to the existing welcome email to the subscriber
- Added `AdminEmail` CloudFormation parameter (defaults to `micah@micahwalter.com`) and passes it as `ADMIN_EMAIL` env var to the `EmailFn` Lambda
- Added `ses:SendEmail` to the `EmailFnRole` IAM policy (previously only `ses:SendTemplatedEmail`)
- Admin notification failure is logged but does **not** fail the SQS message — the subscriber's welcome email is the critical path

## Test plan

- [ ] Deploy updated newsletter stack (`make build && make upload`, then `aws cloudformation deploy ...`)
- [ ] Sign up for the newsletter with a test email
- [ ] Confirm via the confirmation link
- [ ] Verify welcome email is received by the subscriber
- [ ] Verify admin notification email is received at the configured `AdminEmail` address

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)