### PR TITLE
Add /posts page with paginated grid

### DIFF
--- a/app/photos/page.tsx
+++ b/app/photos/page.tsx
@@ -1,6 +1,8 @@
 import { getPhotos } from "@/lib/content";
-import PostGrid from "@/components/PostGrid";
+import PaginatedPostGrid from "@/components/PaginatedPostGrid";
 import type { Metadata } from "next";
+
+const POSTS_PER_PAGE = 12;
 
 export const metadata: Metadata = {
   title: "Photos - Micah Walter",
@@ -26,9 +28,8 @@ export default function PhotosPage() {
         </p>
       </header>
 
-      {/* Photo Grid */}
       {photos.length > 0 ? (
-        <PostGrid posts={photos} featuredFirst={false} />
+        <PaginatedPostGrid posts={photos} perPage={POSTS_PER_PAGE} />
       ) : (
         <div className="max-w-wide mx-auto px-6 py-24 text-center">
           <p className="text-gray text-lg">No photos yet. Check back soon!</p>

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import { getBlogPosts } from "@/lib/content";
+import PaginatedPostGrid from "@/components/PaginatedPostGrid";
+
+export const metadata: Metadata = {
+  title: "Posts",
+  description: "All blog posts.",
+};
+
+const POSTS_PER_PAGE = 12;
+
+export default function PostsPage() {
+  const posts = getBlogPosts();
+
+  return (
+    <div className="min-h-screen">
+      <header className="max-w-wide mx-auto px-6 py-12 border-b border-gray/20">
+        <h1 className="font-serif font-semibold text-4xl md:text-5xl mb-4 text-charcoal">
+          Posts
+        </h1>
+        <p className="text-lg text-gray max-w-reading">
+          All blog posts.
+        </p>
+      </header>
+
+      {posts.length > 0 ? (
+        <PaginatedPostGrid posts={posts} perPage={POSTS_PER_PAGE} />
+      ) : (
+        <div className="max-w-wide mx-auto px-6 py-24 text-center">
+          <p className="text-gray text-lg">No posts yet.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -51,6 +51,14 @@ export default function MobileMenu({ isOpen, onClose, onSearchOpen }: MobileMenu
             </Link>
 
             <Link
+              href="/posts"
+              onClick={onClose}
+              className="block px-4 py-3 text-lg text-charcoal no-underline hover:bg-charcoal/5 rounded-lg transition-colors"
+            >
+              Posts
+            </Link>
+
+            <Link
               href="/photos"
               onClick={onClose}
               className="block px-4 py-3 text-lg text-charcoal no-underline hover:bg-charcoal/5 rounded-lg transition-colors"

--- a/components/PaginatedPostGrid.tsx
+++ b/components/PaginatedPostGrid.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import PostCard from "./PostCard";
+import PhotoCard from "./PhotoCard";
+import type { Post } from "@/lib/content";
+
+interface PaginatedPostGridProps {
+  posts: Post[];
+  perPage: number;
+}
+
+export default function PaginatedPostGrid({ posts, perPage }: PaginatedPostGridProps) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const pageParam = Number(searchParams.get("page")) || 1;
+  const totalPages = Math.ceil(posts.length / perPage);
+  const page = Math.min(Math.max(1, pageParam), totalPages);
+  const paginated = posts.slice((page - 1) * perPage, page * perPage);
+
+  function goToPage(p: number) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (p === 1) {
+      params.delete("page");
+    } else {
+      params.set("page", String(p));
+    }
+    const qs = params.toString();
+    router.push(qs ? `${pathname}?${qs}` : pathname, { scroll: true });
+  }
+
+  return (
+    <div className="max-w-wide mx-auto px-6 py-12">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+        {paginated.map((post) =>
+          post.type === "photo" ? (
+            <PhotoCard key={post.slug} post={post} />
+          ) : (
+            <PostCard key={post.slug} post={post} />
+          )
+        )}
+      </div>
+
+      {totalPages > 1 && (
+        <nav className="mt-12 flex items-center justify-center gap-4">
+          <button
+            onClick={() => goToPage(page - 1)}
+            disabled={page === 1}
+            className="px-4 py-2 text-sm font-medium text-charcoal border border-gray/30 rounded-lg hover:bg-charcoal/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            Previous
+          </button>
+
+          <span className="text-sm text-gray">
+            Page {page} of {totalPages}
+          </span>
+
+          <button
+            onClick={() => goToPage(page + 1)}
+            disabled={page === totalPages}
+            className="px-4 py-2 text-sm font-medium text-charcoal border border-gray/30 rounded-lg hover:bg-charcoal/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            Next
+          </button>
+        </nav>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a new `/posts` route that displays blog posts only (no photos or emails) in a thumbnail grid
- Introduces a shared `PaginatedPostGrid` component with URL-synced pagination (`?page=N`)
- Updates `/photos` to use the same paginated grid
- Adds "Posts" navigation item in the menu above "Photos"

## Test plan
- [ ] Visit `/posts` — should show only blog posts in a thumbnail grid, 12 per page
- [ ] Click Next/Previous — URL updates to `?page=2`, etc. and scrolls to top
- [ ] Visit `/photos` — should show paginated photo grid with same controls
- [ ] Open nav menu — "Posts" link appears above "Photos"
- [ ] Direct visit to `/posts?page=2` loads correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)