### PR TITLE
Fix: wrap useSearchParams in Suspense boundary

### DIFF
--- a/components/PaginatedPostGrid.tsx
+++ b/components/PaginatedPostGrid.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Suspense } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import PostCard from "./PostCard";
 import PhotoCard from "./PhotoCard";
@@ -10,7 +11,7 @@ interface PaginatedPostGridProps {
   perPage: number;
 }
 
-export default function PaginatedPostGrid({ posts, perPage }: PaginatedPostGridProps) {
+function PaginatedPostGridInner({ posts, perPage }: PaginatedPostGridProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -67,5 +68,13 @@ export default function PaginatedPostGrid({ posts, perPage }: PaginatedPostGridP
         </nav>
       )}
     </div>
+  );
+}
+
+export default function PaginatedPostGrid(props: PaginatedPostGridProps) {
+  return (
+    <Suspense>
+      <PaginatedPostGridInner {...props} />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- Wraps `useSearchParams()` in a `<Suspense>` boundary in `PaginatedPostGrid`
- Required for Next.js static export (`output: "export"`) — build fails without it
- Fixes the deploy failure from #42

## Test plan
- [ ] `npm run build` completes without errors
- [ ] `/posts` and `/photos` pages render correctly with pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)