### PR TITLE
Add honeypot field to block spam bot signups

### DIFF
--- a/app/newsletter/SubscribeForm.tsx
+++ b/app/newsletter/SubscribeForm.tsx
@@ -12,6 +12,7 @@ export default function SubscribeForm() {
   const router = useRouter();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
+  const [website, setWebsite] = useState("");
   const [status, setStatus] = useState<Status>("idle");
   const [errorMsg, setErrorMsg] = useState("");
 
@@ -24,7 +25,7 @@ export default function SubscribeForm() {
       const res = await fetch(`${API_URL}/subscribe`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, name }),
+        body: JSON.stringify({ email, name, website }),
       });
 
       if (res.status === 202) {
@@ -66,6 +67,19 @@ export default function SubscribeForm() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-5 max-w-sm">
+      {/* Honeypot: hidden from real users, bots will fill this in */}
+      <div style={{ position: "absolute", left: "-9999px", top: "-9999px" }} aria-hidden="true">
+        <label htmlFor="website">Website</label>
+        <input
+          id="website"
+          type="text"
+          name="website"
+          value={website}
+          onChange={(e) => setWebsite(e.target.value)}
+          tabIndex={-1}
+          autoComplete="off"
+        />
+      </div>
       <div>
         <label
           htmlFor="name"

--- a/infra/newsletter-lambdas/cmd/subscribe/main.go
+++ b/infra/newsletter-lambdas/cmd/subscribe/main.go
@@ -40,14 +40,22 @@ func init() {
 }
 
 type subscribeRequest struct {
-	Email string `json:"email"`
-	Name  string `json:"name"`
+	Email   string `json:"email"`
+	Name    string `json:"name"`
+	Website string `json:"website"`
 }
 
 func handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
 	var body subscribeRequest
 	if err := json.Unmarshal([]byte(req.Body), &body); err != nil {
 		return response(400, "Invalid request body"), nil
+	}
+
+	// Honeypot: real users never fill this hidden field; bots typically do.
+	// Return a fake 202 to avoid alerting bot operators.
+	if body.Website != "" {
+		slog.Info("subscribe: honeypot triggered", "ip", req.RequestContext.HTTP.SourceIP)
+		return response(202, "Check your inbox to confirm your subscription"), nil
 	}
 
 	email := strings.TrimSpace(strings.ToLower(body.Email))


### PR DESCRIPTION
Adds a hidden "website" input field to the subscribe form that is
positioned off-screen (not visible to real users). Bots that
auto-fill all form fields will populate it. The Lambda checks for
a non-empty value and silently returns a fake 202 to avoid alerting
bot operators, while skipping subscriber creation.

Closes #44

https://claude.ai/code/session_01274i6UDpViw4BN6DJa2gnf