### PR TITLE
Add time-based bot check via HMAC form token

### DIFF
--- a/app/newsletter/SubscribeForm.tsx
+++ b/app/newsletter/SubscribeForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { trackEvent } from "fathom-client";
 
@@ -13,8 +13,19 @@ export default function SubscribeForm() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [website, setWebsite] = useState("");
+  const [formToken, setFormToken] = useState("");
   const [status, setStatus] = useState<Status>("idle");
   const [errorMsg, setErrorMsg] = useState("");
+
+  useEffect(() => {
+    fetch(`${API_URL}/formtoken`)
+      .then((r) => r.json())
+      .then((data) => setFormToken(data.token ?? ""))
+      .catch(() => {
+        // Non-fatal: token will be empty and the Lambda will silently drop the
+        // submission, but we don't surface an error to the user here.
+      });
+  }, []);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -25,7 +36,7 @@ export default function SubscribeForm() {
       const res = await fetch(`${API_URL}/subscribe`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, name, website }),
+        body: JSON.stringify({ email, name, website, formToken }),
       });
 
       if (res.status === 202) {

--- a/infra/newsletter-lambdas/Makefile
+++ b/infra/newsletter-lambdas/Makefile
@@ -9,7 +9,7 @@ ARTIFACTS_PREFIX := newsletter/lambda
 BOOTSTRAP_STACK := micahwalter-newsletter-bootstrap
 STACK_NAME      := micahwalter-newsletter
 
-FUNCTIONS := subscribe confirm unsubscribe email dispatch
+FUNCTIONS := subscribe confirm unsubscribe email dispatch formtoken
 
 DIST := dist
 

--- a/infra/newsletter-lambdas/cmd/formtoken/main.go
+++ b/infra/newsletter-lambdas/cmd/formtoken/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/config"
+
+	"github.com/micahwalter/newsletter-lambdas/internal/formtoken"
+	"github.com/micahwalter/newsletter-lambdas/internal/secrets"
+)
+
+var secClient *secrets.Client
+
+func init() {
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		slog.Error("failed to load AWS config", "err", err)
+		os.Exit(1)
+	}
+	secClient = secrets.NewClient(cfg, os.Getenv("HMAC_SECRET_ARN"))
+}
+
+func handler(ctx context.Context, _ events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	keys, err := secClient.Keys(ctx)
+	if err != nil {
+		slog.Error("formtoken: failed to load secrets", "err", err)
+		return response(500, "Internal error"), nil
+	}
+
+	tok, err := formtoken.Issue(keys.Current)
+	if err != nil {
+		slog.Error("formtoken: failed to issue token", "err", err)
+		return response(500, "Internal error"), nil
+	}
+
+	body, _ := json.Marshal(map[string]string{"token": tok})
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: 200,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       string(body),
+	}, nil
+}
+
+func main() {
+	lambda.Start(handler)
+}
+
+func response(statusCode int, message string) events.APIGatewayV2HTTPResponse {
+	body, _ := json.Marshal(map[string]string{"message": message})
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       string(body),
+	}
+}

--- a/infra/newsletter-lambdas/cmd/subscribe/main.go
+++ b/infra/newsletter-lambdas/cmd/subscribe/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/micahwalter/newsletter-lambdas/internal/dynamo"
 	evts "github.com/micahwalter/newsletter-lambdas/internal/events"
+	"github.com/micahwalter/newsletter-lambdas/internal/formtoken"
 	"github.com/micahwalter/newsletter-lambdas/internal/secrets"
 	"github.com/micahwalter/newsletter-lambdas/internal/token"
 )
@@ -40,9 +41,10 @@ func init() {
 }
 
 type subscribeRequest struct {
-	Email   string `json:"email"`
-	Name    string `json:"name"`
-	Website string `json:"website"`
+	Email     string `json:"email"`
+	Name      string `json:"name"`
+	Website   string `json:"website"`
+	FormToken string `json:"formToken"`
 }
 
 func handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
@@ -51,10 +53,28 @@ func handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.AP
 		return response(400, "Invalid request body"), nil
 	}
 
+	// Load HMAC keys early — needed for both bot checks and token signing.
+	keys, err := secClient.Keys(ctx)
+	if err != nil {
+		slog.Error("subscribe: failed to load secrets", "err", err)
+		return response(500, "Internal error"), nil
+	}
+
 	// Honeypot: real users never fill this hidden field; bots typically do.
 	// Return a fake 202 to avoid alerting bot operators.
 	if body.Website != "" {
 		slog.Info("subscribe: honeypot triggered", "ip", req.RequestContext.HTTP.SourceIP)
+		return response(202, "Check your inbox to confirm your subscription"), nil
+	}
+
+	// Time-based check: the form token is issued when the page loads and must
+	// be at least 3 seconds old. Bots that submit instantly are silently dropped.
+	if body.FormToken == "" {
+		slog.Info("subscribe: missing form token", "ip", req.RequestContext.HTTP.SourceIP)
+		return response(202, "Check your inbox to confirm your subscription"), nil
+	}
+	if err := formtoken.Verify(body.FormToken, keys.Current, keys.Previous); err != nil {
+		slog.Info("subscribe: form token rejected", "ip", req.RequestContext.HTTP.SourceIP, "reason", err)
 		return response(202, "Check your inbox to confirm your subscription"), nil
 	}
 
@@ -66,12 +86,6 @@ func handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.AP
 	}
 	if name == "" {
 		name = "there"
-	}
-
-	keys, err := secClient.Keys(ctx)
-	if err != nil {
-		slog.Error("subscribe: failed to load secrets", "err", err)
-		return response(500, "Internal error"), nil
 	}
 
 	existing, err := db.Get(ctx, email)

--- a/infra/newsletter-lambdas/internal/formtoken/formtoken.go
+++ b/infra/newsletter-lambdas/internal/formtoken/formtoken.go
@@ -1,0 +1,101 @@
+// Package formtoken issues and verifies HMAC-signed form load tokens used for
+// time-based bot detection. A token encodes the time the subscribe form was
+// loaded. On submission the Lambda verifies:
+//
+//   - The HMAC signature matches (prevents token forgery).
+//   - At least 3 seconds have elapsed (bots submit in < 1s).
+//   - No more than 1 hour has elapsed (prevents replay with stale tokens).
+//
+// Token structure (same scheme as the token package):
+//
+//	payload   = base64url( "form" + "|" + issued_at_unix )
+//	signature = HMAC-SHA256( payload, secret )
+//	token     = payload + "." + signature
+package formtoken
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	ErrInvalid  = errors.New("formtoken: invalid")
+	ErrTooFast  = errors.New("formtoken: submitted too fast")
+	ErrExpired  = errors.New("formtoken: expired")
+)
+
+const (
+	minAge = 3 * time.Second
+	maxAge = time.Hour
+)
+
+// Issue creates a signed form token recording the current time.
+func Issue(secret string) (string, error) {
+	if secret == "" {
+		return "", fmt.Errorf("formtoken: secret must not be empty")
+	}
+	issuedAt := time.Now().Unix()
+	payload := base64.RawURLEncoding.EncodeToString(
+		[]byte("form|" + strconv.FormatInt(issuedAt, 10)),
+	)
+	sig := sign(payload, secret)
+	return payload + "." + sig, nil
+}
+
+// Verify validates a form token's signature and timing.
+// It tries currentSecret first, then previousSecret (for key rotation).
+func Verify(tok, currentSecret, previousSecret string) error {
+	parts := strings.SplitN(tok, ".", 2)
+	if len(parts) != 2 {
+		return ErrInvalid
+	}
+	payload, providedSig := parts[0], parts[1]
+
+	if !verifySig(payload, providedSig, currentSecret) {
+		if previousSecret == "" || !verifySig(payload, providedSig, previousSecret) {
+			return ErrInvalid
+		}
+	}
+
+	raw, err := base64.RawURLEncoding.DecodeString(payload)
+	if err != nil {
+		return ErrInvalid
+	}
+
+	fields := strings.SplitN(string(raw), "|", 2)
+	if len(fields) != 2 || fields[0] != "form" {
+		return ErrInvalid
+	}
+
+	issuedAt, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return ErrInvalid
+	}
+
+	age := time.Since(time.Unix(issuedAt, 0))
+	if age < minAge {
+		return ErrTooFast
+	}
+	if age > maxAge {
+		return ErrExpired
+	}
+	return nil
+}
+
+func sign(payload, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(payload))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func verifySig(payload, providedSig, key string) bool {
+	expected := sign(payload, key)
+	return subtle.ConstantTimeCompare([]byte(providedSig), []byte(expected)) == 1
+}

--- a/infra/newsletter.yml
+++ b/infra/newsletter.yml
@@ -258,6 +258,7 @@ Resources:
         AllowOrigins:
           - !Ref SiteUrl
         AllowMethods:
+          - GET
           - POST
           - OPTIONS
         AllowHeaders:
@@ -652,6 +653,87 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${NewsletterApi}/*/*/unsubscribe
+
+  FormTokenFnRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: newsletter-formtoken-fn-role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: FormTokenFnPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource: !Ref HMACSecret
+      Tags:
+        - Key: Project
+          Value: micahwalter-newsletter
+        - Key: Environment
+          Value: Production
+        - Key: Application
+          Value: NewsletterSubscription
+        - Key: ManagedBy
+          Value: CloudFormation
+
+  FormTokenFn:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: newsletter-formtoken
+      Runtime: provided.al2023
+      Architectures: [arm64]
+      Handler: bootstrap
+      Role: !GetAtt FormTokenFnRole.Arn
+      Code:
+        S3Bucket: !Ref LambdaArtifactsBucket
+        S3Key: !Sub ${LambdaArtifactsKeyPrefix}/formtoken.zip
+      Timeout: 5
+      MemorySize: 128
+      Environment:
+        Variables:
+          HMAC_SECRET_ARN: !Ref HMACSecret
+      Tags:
+        - Key: Project
+          Value: micahwalter-newsletter
+        - Key: Environment
+          Value: Production
+        - Key: Application
+          Value: NewsletterSubscription
+        - Key: ManagedBy
+          Value: CloudFormation
+
+  FormTokenIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref NewsletterApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !Sub
+        arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FormTokenFn.Arn}/invocations
+      PayloadFormatVersion: '2.0'
+
+  FormTokenRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref NewsletterApi
+      RouteKey: GET /formtoken
+      Target: !Sub integrations/${FormTokenIntegration}
+
+  FormTokenFnPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref FormTokenFn
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${NewsletterApi}/*/*/formtoken
 
   # -------------------------------------------------------------------------
   # SQS → email-fn event source mapping


### PR DESCRIPTION
## Summary

Adds a new `GET /formtoken` Lambda that issues a signed HMAC timestamp
token when the subscribe form loads. The subscribe Lambda validates the
token on submission: valid signature, at least 3s old (blocks instant
bots), and no more than 1h old (prevents replay). Invalid or missing
tokens receive a silent fake 202 to avoid alerting bot operators.

## Changes

- **`internal/formtoken`** — new package with `Issue` and `Verify` (enforces `3s ≤ age ≤ 1h`, supports dual-key rotation)
- **`cmd/formtoken/main.go`** — new Lambda serving `GET /formtoken`
- **`cmd/subscribe/main.go`** — loads HMAC keys early, checks form token after honeypot
- **`SubscribeForm.tsx`** — fetches token on mount via `useEffect`, includes it in the subscribe POST body as `formToken`
- **`newsletter.yml`** — adds `FormTokenFnRole`, `FormTokenFn`, integration, route, permission; adds `GET` to CORS `AllowMethods`
- **`Makefile`** — adds `formtoken` to `FUNCTIONS`

## Deploy note

Requires a full CloudFormation stack update (`make deploy`) since new
resources were added — `make update-functions` alone is not sufficient.

## Test plan

- [ ] Load the newsletter page and confirm a `GET /formtoken` request fires on mount
- [ ] Submit the form normally (after ≥3s) — subscription should succeed as before
- [ ] Submit with no token — should receive 202 with no subscriber created
- [ ] Submit with a freshly issued token immediately — silently rejected (ErrTooFast)
- [ ] Submit with a token >1h old — silently rejected (ErrExpired)

Closes #44