### PR TITLE
Add multi-region failover with S3 CRR and CloudFront origin groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,17 @@ A modern, statically-exported blog and photo archive built with Next.js 15 and h
 flowchart TD
     Visitor([Visitor]) --> R53[Route53 DNS]
 
-    R53 -->|www.micahwalter.com| CFMain[CloudFront Main Distribution]
+    R53 -->|www.micahwalter.com| CFMain[CloudFront\nOrigin Groups]
     R53 -->|micahwalter.com| CFApex[CloudFront Apex Redirect]
     CFApex -->|301 to www| CFMain
 
-    CFMain -->|HTML / CSS / JS| S3Web[(S3 Website Bucket)]
-    CFMain -->|Images| S3Img[(S3 Images Bucket)]
+    CFMain -->|HTML / CSS / JS\nprimary| S3Web[(S3 Website\nus-east-1)]
+    CFMain -->|Images\nprimary| S3Img[(S3 Images\nus-east-1)]
+    CFMain -. failover .-> S3WebSec[(S3 Website\nus-east-2)]
+    CFMain -. failover .-> S3ImgSec[(S3 Images\nus-east-2)]
+
+    S3Web -->|CRR| S3WebSec
+    S3Img -->|CRR| S3ImgSec
 
     Dev([Developer]) -->|git push| GH[GitHub]
     Dev -->|blog images:sync| S3Img
@@ -26,12 +31,14 @@ flowchart TD
     classDef dns fill:#c9e6f0,stroke:#5ba3be,color:#191919
     classDef cdn fill:#b3d9f5,stroke:#3a8fc7,color:#191919
     classDef storage fill:#c8f0d8,stroke:#3da85e,color:#191919
+    classDef secondary fill:#d8f0c8,stroke:#5a9e3a,color:#191919
     classDef cicd fill:#e0d4f5,stroke:#8a5ec7,color:#191919
 
     class Visitor,Dev people
     class R53 dns
     class CFMain,CFApex cdn
     class S3Web,S3Img storage
+    class S3WebSec,S3ImgSec secondary
     class GH,Build cicd
 ```
 
@@ -826,16 +833,22 @@ make update-functions
 
 ### AWS Resources
 
-**Main Stack (CloudFormation — `infra/infra.yml`):**
-- S3 Website Bucket (static HTML/JS/CSS)
-- S3 Images Bucket (optimized images)
-- S3 Logs Bucket (access logs)
-- ACM Certificate (`www.micahwalter.com` + `micahwalter.com`, DNS validated)
-- CloudFront Distribution (CDN for `www.micahwalter.com`)
-- CloudFront Apex Redirect Distribution (`micahwalter.com` → 301 → `www.micahwalter.com`)
-- CloudFront Functions (SPA routing + apex redirect)
+**Main Stack (CloudFormation — `infra/infra.yml`, us-east-1):**
+- S3 Website Bucket — static HTML/JS/CSS (versioned, AES256, OAC)
+- S3 Images Bucket — optimized images (versioned, AES256, OAC)
+- S3 Logs Bucket — CloudFront + S3 access logs (90-day lifecycle)
+- ACM Certificate — `www.micahwalter.com` + `micahwalter.com` (DNS validated)
+- CloudFront Distribution — origin groups with automatic failover to us-east-2
+- CloudFront Apex Redirect Distribution — `micahwalter.com` → 301 → `www.micahwalter.com`
+- CloudFront Functions — SPA routing + apex redirect
 - Route53 A/AAAA alias records for both domains
-- Origin Access Control (secure S3 access)
+- Origin Access Control (OAC) — primary + secondary origins
+- IAM Replication Role — S3 Cross-Region Replication to us-east-2
+
+**Secondary Stack (CloudFormation — `infra/infra-secondary.yml`, us-east-2):**
+- S3 Secondary Website Bucket — CRR destination, versioned
+- S3 Secondary Images Bucket — CRR destination, versioned
+- Bucket policies allowing the primary CloudFront distribution via OAC
 
 **GitHub Actions Stack (`infra/github-actions-role.yml`):**
 - IAM Role with OIDC provider
@@ -844,32 +857,37 @@ make update-functions
 ### Initial Infrastructure Setup
 
 ```bash
-# Deploy main infrastructure (requires HostedZoneId from Route53)
-aws cloudformation create-stack \
-  --stack-name micahwalter-www \
-  --template-body file://infra/infra.yml \
-  --parameters \
-    ParameterKey=HostedZoneId,ParameterValue=<your-hosted-zone-id> \
-    ParameterKey=DomainName,ParameterValue=micahwalter.com \
-    ParameterKey=WWWDomainName,ParameterValue=www.micahwalter.com \
-  --profile www \
-  --region us-east-1
+# 1. Deploy secondary stack first (CRR destination must exist before source)
+AWS_PROFILE=www aws cloudformation deploy \
+  --stack-name micahwalter-www-secondary \
+  --template-file infra/infra-secondary.yml \
+  --region us-east-2 \
+  --parameter-overrides CloudFrontDistributionId=<dist-id>
 
-# Deploy GitHub Actions OIDC role
-aws cloudformation create-stack \
-  --stack-name micahwalter-www-github-actions \
-  --template-body file://infra/github-actions-role.yml \
+# 2. Deploy main infrastructure (requires HostedZoneId from Route53)
+#    CAPABILITY_NAMED_IAM required for the S3 replication IAM role
+AWS_PROFILE=www aws cloudformation deploy \
+  --stack-name micahwalter-www \
+  --template-file infra/infra.yml \
+  --region us-east-1 \
   --capabilities CAPABILITY_NAMED_IAM \
-  --profile www \
-  --region us-east-1
+  --parameter-overrides \
+    HostedZoneId=<your-hosted-zone-id> \
+    DomainName=micahwalter.com \
+    WWWDomainName=www.micahwalter.com
 
-# Wait for completion (5-15 minutes)
-aws cloudformation wait stack-create-complete \
-  --stack-name micahwalter-www \
-  --profile www \
-  --region us-east-1
+# 3. Backfill existing objects into secondary buckets
+#    (CRR only replicates objects created after the rule is enabled)
+./scripts/backfill-secondary.sh
 
-# Get IAM role ARN for GitHub Actions
+# 4. Deploy GitHub Actions OIDC role
+AWS_PROFILE=www aws cloudformation deploy \
+  --stack-name micahwalter-www-github-actions \
+  --template-file infra/github-actions-role.yml \
+  --region us-east-1 \
+  --capabilities CAPABILITY_NAMED_IAM
+
+# 5. Add GitHub Actions secrets
 aws cloudformation describe-stacks \
   --stack-name micahwalter-www-github-actions \
   --profile www \
@@ -877,7 +895,6 @@ aws cloudformation describe-stacks \
   --query 'Stacks[0].Outputs[?OutputKey==`RoleArn`].OutputValue' \
   --output text
 
-# Add role ARN as GitHub secret
 gh secret set AWS_ROLE_ARN --body "<role-arn>"
 ```
 
@@ -903,24 +920,29 @@ aws cloudformation describe-stacks \
 ### Update Infrastructure
 
 ```bash
-# Update main stack
-aws cloudformation update-stack \
+# Update secondary stack (us-east-2)
+AWS_PROFILE=www aws cloudformation deploy \
+  --stack-name micahwalter-www-secondary \
+  --template-file infra/infra-secondary.yml \
+  --region us-east-2
+
+# Update main stack (us-east-1)
+AWS_PROFILE=www aws cloudformation deploy \
   --stack-name micahwalter-www \
-  --template-body file://infra/infra.yml \
-  --parameters \
-    ParameterKey=HostedZoneId,ParameterValue=<your-hosted-zone-id> \
-    ParameterKey=DomainName,ParameterValue=micahwalter.com \
-    ParameterKey=WWWDomainName,ParameterValue=www.micahwalter.com \
-  --profile www \
-  --region us-east-1
+  --template-file infra/infra.yml \
+  --region us-east-1 \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides \
+    HostedZoneId=<your-hosted-zone-id> \
+    DomainName=micahwalter.com \
+    WWWDomainName=www.micahwalter.com
 
 # Update GitHub Actions role
-aws cloudformation update-stack \
+AWS_PROFILE=www aws cloudformation deploy \
   --stack-name micahwalter-www-github-actions \
-  --template-body file://infra/github-actions-role.yml \
-  --capabilities CAPABILITY_NAMED_IAM \
-  --profile www \
-  --region us-east-1
+  --template-file infra/github-actions-role.yml \
+  --region us-east-1 \
+  --capabilities CAPABILITY_NAMED_IAM
 ```
 
 ### Manual Deployment (Advanced)
@@ -1035,6 +1057,9 @@ Defined in `tailwind.config.ts`:
 - ✅ Access logging for S3 and CloudFront
 - ✅ Origin Access Control (OAC)
 - ✅ Smart caching (1 year static, revalidate HTML)
+- ✅ Multi-region resilience — secondary buckets in us-east-2 with S3 Cross-Region Replication
+- ✅ Automatic per-request failover via CloudFront origin groups (no DNS changes, no manual intervention)
+- ✅ Delete marker replication — secondary stays in sync when content is removed
 
 ### CI/CD Features
 - ✅ Automated build and deployment
@@ -1070,12 +1095,14 @@ For a blog with 100 posts, 1 cover image each, 10K pageviews/month:
 
 | Service | Usage | Cost |
 |---------|-------|------|
-| S3 Storage | 60 MB images + 10 MB site | $0.002 |
+| S3 Storage (primary) | 60 MB images + 10 MB site | $0.002 |
+| S3 Storage (secondary, us-east-2) | Same data replicated | $0.002 |
+| S3 CRR transfer | ~70 MB/month inter-region | $0.001 |
 | S3 Requests | Minimal (CI uploads only) | $0.001 |
 | CloudFront | 1 GB transfer (optimized images) | $0.085 |
 | **Total** | | **~$0.09/month** |
 
-Without optimization: ~$0.70/month (87% savings)
+Multi-region resilience adds ~$0.003/month for this site size. CloudFront origin groups are free.
 
 ## Troubleshooting
 

--- a/infra/infra-secondary.yml
+++ b/infra/infra-secondary.yml
@@ -1,0 +1,147 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Secondary region buckets for micahwalter-www cross-region failover (us-east-2)'
+
+# Deploy this stack to us-east-2 BEFORE updating the primary infra.yml stack:
+#
+#   AWS_PROFILE=www aws cloudformation deploy \
+#     --stack-name micahwalter-www-secondary \
+#     --template-file infra/infra-secondary.yml \
+#     --region us-east-2 \
+#     --parameter-overrides \
+#       CloudFrontDistributionId=E1SZIKPZ79BHDU
+#
+# After deploying, run the primary stack update (infra.yml) to enable CRR and origin groups.
+# Then run scripts/backfill-secondary.sh to sync existing objects into the secondary buckets.
+
+Parameters:
+  CloudFrontDistributionId:
+    Type: String
+    Default: E1SZIKPZ79BHDU
+    Description: CloudFront distribution ID from primary stack (infra.yml output)
+
+Resources:
+  # Secondary S3 bucket for website content (us-east-2)
+  # Versioning must be enabled for CRR destination buckets.
+  SecondaryWebsiteBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: micahwalter-www-secondary-website
+      VersioningConfiguration:
+        Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+          - Id: DeleteOldVersions
+            Status: Enabled
+            NoncurrentVersionExpirationInDays: 365
+      Tags:
+        - Key: Project
+          Value: micahwalter-www
+        - Key: Environment
+          Value: Production
+        - Key: Application
+          Value: StaticWebsite
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: Purpose
+          Value: SecondaryWebsiteContent
+        - Key: Region
+          Value: Secondary
+
+  # Secondary S3 bucket for optimized blog post images (us-east-2)
+  SecondaryImagesBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: micahwalter-www-secondary-images
+      VersioningConfiguration:
+        Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+          - Id: DeleteOldVersions
+            Status: Enabled
+            NoncurrentVersionExpirationInDays: 365
+      Tags:
+        - Key: Project
+          Value: micahwalter-www
+        - Key: Environment
+          Value: Production
+        - Key: Application
+          Value: StaticWebsite
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: Purpose
+          Value: SecondaryBlogImages
+        - Key: Region
+          Value: Secondary
+
+  # Allow the primary CloudFront distribution to read from the secondary website bucket via OAC.
+  # OAC signs requests with SigV4; CloudFront presents as cloudfront.amazonaws.com with the
+  # distribution ARN in AWS:SourceArn.
+  SecondaryWebsiteBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref SecondaryWebsiteBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowCloudFrontOAC
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: s3:GetObject
+            Resource: !Sub '${SecondaryWebsiteBucket.Arn}/*'
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistributionId}'
+
+  # Allow the primary CloudFront distribution to read from the secondary images bucket via OAC.
+  SecondaryImagesBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref SecondaryImagesBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowCloudFrontOAC
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: s3:GetObject
+            Resource: !Sub '${SecondaryImagesBucket.Arn}/*'
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistributionId}'
+
+Outputs:
+  SecondaryWebsiteBucketName:
+    Description: Secondary website bucket name (us-east-2)
+    Value: !Ref SecondaryWebsiteBucket
+
+  SecondaryWebsiteBucketArn:
+    Description: Secondary website bucket ARN (us-east-2)
+    Value: !GetAtt SecondaryWebsiteBucket.Arn
+
+  SecondaryImagesBucketName:
+    Description: Secondary images bucket name (us-east-2)
+    Value: !Ref SecondaryImagesBucket
+
+  SecondaryImagesBucketArn:
+    Description: Secondary images bucket ARN (us-east-2)
+    Value: !GetAtt SecondaryImagesBucket.Arn

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -16,7 +16,73 @@ Parameters:
     Default: www.micahwalter.com
     Description: WWW subdomain name
 
+  SecondaryWebsiteBucketName:
+    Type: String
+    Default: micahwalter-www-secondary-website
+    Description: Secondary S3 bucket name for website content (us-east-2, from infra-secondary.yml)
+
+  SecondaryImagesBucketName:
+    Type: String
+    Default: micahwalter-www-secondary-images
+    Description: Secondary S3 bucket name for images (us-east-2, from infra-secondary.yml)
+
 Resources:
+  # IAM role used by S3 Cross-Region Replication (CRR) to copy objects to the secondary buckets.
+  # Must be created before the buckets that reference it via ReplicationConfiguration.
+  ReplicationRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${AWS::StackName}-replication-role'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: s3.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: S3CRRPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ReadSourceBuckets
+                Effect: Allow
+                Action:
+                  - s3:GetReplicationConfiguration
+                  - s3:ListBucket
+                Resource:
+                  - !Sub 'arn:aws:s3:::${AWS::StackName}-website'
+                  - !Sub 'arn:aws:s3:::${AWS::StackName}-images'
+              - Sid: ReadSourceObjects
+                Effect: Allow
+                Action:
+                  - s3:GetObjectVersionForReplication
+                  - s3:GetObjectVersionAcl
+                  - s3:GetObjectVersionTagging
+                Resource:
+                  - !Sub 'arn:aws:s3:::${AWS::StackName}-website/*'
+                  - !Sub 'arn:aws:s3:::${AWS::StackName}-images/*'
+              - Sid: WriteDestinationBuckets
+                Effect: Allow
+                Action:
+                  - s3:ReplicateObject
+                  - s3:ReplicateDelete
+                  - s3:ReplicateTags
+                Resource:
+                  - !Sub 'arn:aws:s3:::${SecondaryWebsiteBucketName}/*'
+                  - !Sub 'arn:aws:s3:::${SecondaryImagesBucketName}/*'
+      Tags:
+        - Key: Project
+          Value: micahwalter-www
+        - Key: Environment
+          Value: Production
+        - Key: Application
+          Value: StaticWebsite
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: Purpose
+          Value: S3CrossRegionReplication
+
   # S3 Bucket for access logs
   LogsBucket:
     Type: AWS::S3::Bucket
@@ -75,6 +141,23 @@ Resources:
           - Id: DeleteOldVersions
             Status: Enabled
             NoncurrentVersionExpirationInDays: 365
+      # CRR: asynchronously copy every new/updated object to the secondary bucket in us-east-2.
+      # Only objects created/modified AFTER this rule is enabled are replicated automatically;
+      # run scripts/backfill-secondary.sh once to sync pre-existing objects.
+      ReplicationConfiguration:
+        Role: !GetAtt ReplicationRole.Arn
+        Rules:
+          - Id: ReplicateWebsiteToSecondary
+            Status: Enabled
+            Priority: 1
+            # Filter + Priority required by V2 schema to enable DeleteMarkerReplication
+            Filter:
+              Prefix: ''
+            Destination:
+              Bucket: !Sub 'arn:aws:s3:::${SecondaryWebsiteBucketName}'
+              StorageClass: STANDARD
+            DeleteMarkerReplication:
+              Status: Enabled
       Tags:
         - Key: Project
           Value: micahwalter-www
@@ -111,6 +194,19 @@ Resources:
           - Id: DeleteOldVersions
             Status: Enabled
             NoncurrentVersionExpirationInDays: 365
+      ReplicationConfiguration:
+        Role: !GetAtt ReplicationRole.Arn
+        Rules:
+          - Id: ReplicateImagesToSecondary
+            Status: Enabled
+            Priority: 1
+            Filter:
+              Prefix: ''
+            Destination:
+              Bucket: !Sub 'arn:aws:s3:::${SecondaryImagesBucketName}'
+              StorageClass: STANDARD
+            DeleteMarkerReplication:
+              Status: Enabled
       Tags:
         - Key: Project
           Value: micahwalter-www
@@ -163,6 +259,26 @@ Resources:
     Properties:
       OriginAccessControlConfig:
         Name: !Sub '${AWS::StackName}-images-OAC'
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
+
+  # CloudFront Origin Access Control for secondary website bucket (us-east-2)
+  CloudFrontSecondaryWebsiteOAC:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: !Sub '${AWS::StackName}-secondary-website-OAC'
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
+
+  # CloudFront Origin Access Control for secondary images bucket (us-east-2)
+  CloudFrontSecondaryImagesOAC:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: !Sub '${AWS::StackName}-secondary-images-OAC'
         OriginAccessControlOriginType: s3
         SigningBehavior: always
         SigningProtocol: sigv4
@@ -220,6 +336,9 @@ Resources:
         Runtime: cloudfront-js-1.0
 
   # Main CloudFront Distribution (www.micahwalter.com)
+  # Uses origin groups for automatic per-request failover to us-east-2 secondary buckets.
+  # On a 403/5xx from the primary origin, CloudFront immediately retries the secondary.
+  # No DNS changes or manual intervention required during a regional S3 outage.
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
     Properties:
@@ -235,20 +354,61 @@ Resources:
           SslSupportMethod: sni-only
           MinimumProtocolVersion: TLSv1.2_2021
         Origins:
+          # Primary website bucket (us-east-1)
           - Id: S3Origin
             DomainName: !GetAtt WebsiteBucket.RegionalDomainName
             S3OriginConfig:
               OriginAccessIdentity: ''
             OriginAccessControlId: !Ref CloudFrontOAC
+          # Primary images bucket (us-east-1)
           - Id: ImagesOrigin
             DomainName: !GetAtt ImagesBucket.RegionalDomainName
             S3OriginConfig:
               OriginAccessIdentity: ''
             OriginAccessControlId: !Ref CloudFrontImagesOAC
+          # Secondary website bucket (us-east-2) — failover target
+          - Id: S3OriginSecondary
+            DomainName: !Sub '${SecondaryWebsiteBucketName}.s3.us-east-2.amazonaws.com'
+            S3OriginConfig:
+              OriginAccessIdentity: ''
+            OriginAccessControlId: !Ref CloudFrontSecondaryWebsiteOAC
+          # Secondary images bucket (us-east-2) — failover target
+          - Id: ImagesOriginSecondary
+            DomainName: !Sub '${SecondaryImagesBucketName}.s3.us-east-2.amazonaws.com'
+            S3OriginConfig:
+              OriginAccessIdentity: ''
+            OriginAccessControlId: !Ref CloudFrontSecondaryImagesOAC
+        # Origin groups enable automatic per-request failover.
+        # 403: S3 can return this during bucket-level access failures (not just "file not found").
+        # 5xx: covers connection timeouts and service errors.
+        # 404 is intentionally excluded — a missing page on primary is a real 404, not a failure.
+        OriginGroups:
+          Quantity: 2
+          Items:
+            - Id: WebsiteOriginGroup
+              FailoverCriteria:
+                StatusCodes:
+                  Quantity: 5
+                  Items: [403, 500, 502, 503, 504]
+              Members:
+                Quantity: 2
+                Items:
+                  - OriginId: S3Origin
+                  - OriginId: S3OriginSecondary
+            - Id: ImagesOriginGroup
+              FailoverCriteria:
+                StatusCodes:
+                  Quantity: 5
+                  Items: [403, 500, 502, 503, 504]
+              Members:
+                Quantity: 2
+                Items:
+                  - OriginId: ImagesOrigin
+                  - OriginId: ImagesOriginSecondary
         CacheBehaviors:
-          # Cache behavior for optimized blog post images
+          # Cache behavior for optimized blog post images — uses images origin group
           - PathPattern: '/images/*'
-            TargetOriginId: ImagesOrigin
+            TargetOriginId: ImagesOriginGroup
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods:
               - GET
@@ -261,7 +421,7 @@ Resources:
             Compress: true
             CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6  # Managed-CachingOptimized
         DefaultCacheBehavior:
-          TargetOriginId: S3Origin
+          TargetOriginId: WebsiteOriginGroup
           ViewerProtocolPolicy: redirect-to-https
           AllowedMethods:
             - GET
@@ -276,6 +436,8 @@ Resources:
           FunctionAssociations:
             - EventType: viewer-request
               FunctionARN: !GetAtt StaticHTMLRoutingFunction.FunctionARN
+        # Custom error responses apply after both origins in a group have been tried.
+        # 403 and 404 from S3 (with OAC) both map to the themed 404 page.
         CustomErrorResponses:
           - ErrorCode: 403
             ResponseCode: 404

--- a/scripts/backfill-secondary.sh
+++ b/scripts/backfill-secondary.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# scripts/backfill-secondary.sh
+#
+# Syncs primary S3 buckets (us-east-1) to secondary buckets (us-east-2).
+#
+# When to run:
+#   1. Once immediately after enabling CRR (CRR only replicates objects
+#      created/modified AFTER the replication rule is activated).
+#   2. Any time you suspect the secondary is out of sync (e.g. after
+#      manually deleting objects from the secondary, or after a period
+#      where replication was disabled).
+#
+# Usage:
+#   ./scripts/backfill-secondary.sh                  # uses AWS_PROFILE=www
+#   AWS_PROFILE=other ./scripts/backfill-secondary.sh
+
+set -euo pipefail
+
+AWS_PROFILE="${AWS_PROFILE:-www}"
+
+PRIMARY_WEBSITE="micahwalter-www-website"
+SECONDARY_WEBSITE="micahwalter-www-secondary-website"
+
+PRIMARY_IMAGES="micahwalter-www-images"
+SECONDARY_IMAGES="micahwalter-www-secondary-images"
+
+echo "==> Backfilling website bucket..."
+echo "    s3://${PRIMARY_WEBSITE}/ -> s3://${SECONDARY_WEBSITE}/"
+aws s3 sync \
+  "s3://${PRIMARY_WEBSITE}/" \
+  "s3://${SECONDARY_WEBSITE}/" \
+  --profile "${AWS_PROFILE}"
+
+echo ""
+echo "==> Backfilling images bucket..."
+echo "    s3://${PRIMARY_IMAGES}/ -> s3://${SECONDARY_IMAGES}/"
+aws s3 sync \
+  "s3://${PRIMARY_IMAGES}/" \
+  "s3://${SECONDARY_IMAGES}/" \
+  --profile "${AWS_PROFILE}"
+
+echo ""
+echo "Backfill complete."


### PR DESCRIPTION
Closes #47

## What this does

Implements automatic cross-region failover for the static website with zero manual intervention required during a regional S3 outage.

## Architecture

- **Primary buckets** (us-east-1): unchanged — GitHub Actions still deploys here only
- **Secondary buckets** (us-east-2): `micahwalter-www-secondary-website` + `micahwalter-www-secondary-images`
- **S3 Cross-Region Replication**: all new objects + delete markers replicate automatically from primary → secondary
- **CloudFront origin groups**: on 403/500/502/503/504 from primary, CloudFront silently retries the secondary per-request — no DNS propagation delay, no human intervention

## Changes

| File | Change |
|------|--------|
| `infra/infra-secondary.yml` | New stack (us-east-2): secondary buckets with versioning and OAC bucket policies |
| `infra/infra.yml` | Adds `ReplicationRole`, CRR config on both buckets (V2 schema), secondary OACs, four origins + two origin groups in CloudFront |
| `scripts/backfill-secondary.sh` | One-shot sync script for pre-existing objects |
| `README.md` | Updated arch diagram, infrastructure section, setup commands, features list, cost table |

## Deploy sequence (already done)

1. `micahwalter-www-secondary` stack deployed to us-east-2 ✅
2. `micahwalter-www` primary stack updated (CRR active, origin groups live) ✅  
3. `scripts/backfill-secondary.sh` run — ~389 MB synced to secondary ✅

## Cost impact

~$0.003/month additional for this site size. CloudFront origin groups are free.