### PR TITLE
Constrain featured images to viewport height (Flickr-style)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,7 @@ export default function Home() {
           className="rounded-lg"
           priority={true}
           sizes="(max-width: 768px) 100vw, 1340px"
+          viewportFit={true}
         />
       </Link>
       <p className="mt-4 text-center text-charcoal">

--- a/components/PhotoLayout.tsx
+++ b/components/PhotoLayout.tsx
@@ -30,6 +30,7 @@ export default function PhotoLayout({ post, children }: PhotoLayoutProps) {
             priority={true}
             sizes="(max-width: 768px) 100vw, 1340px"
             zoomable={true}
+            viewportFit={true}
           />
         </div>
       )}

--- a/components/ResponsiveImage.tsx
+++ b/components/ResponsiveImage.tsx
@@ -41,6 +41,8 @@ interface ResponsiveImageProps {
   height?: number;
   /** Enable zoom on click (desktop only, defaults to false) */
   zoomable?: boolean;
+  /** Constrain image to viewport height on desktop so the full image is visible without scrolling (Flickr-style) */
+  viewportFit?: boolean;
 }
 
 const SIZES = [400, 800, 1200];
@@ -70,6 +72,7 @@ export default function ResponsiveImage({
   width,
   height,
   zoomable = false,
+  viewportFit = false,
 }: ResponsiveImageProps) {
   const [isZoomed, setIsZoomed] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
@@ -134,6 +137,18 @@ export default function ResponsiveImage({
     ? `${className} cursor-zoom-in hover:opacity-90 transition-opacity`
     : className;
 
+  // When viewportFit, constrain the image to viewport height on desktop so
+  // the full image (portrait or landscape) is always visible without scrolling.
+  const imgStyle = viewportFit
+    ? { width: '100%', height: 'auto' }
+    : aspectRatio
+      ? { aspectRatio: `${width} / ${height}`, width: '100%', height: 'auto' }
+      : { width: '100%', height: 'auto' };
+
+  const imgClassName = viewportFit
+    ? 'object-contain md:max-h-[calc(100vh-180px)]'
+    : 'object-cover';
+
   return (
     <>
       <picture className={pictureClassName} onClick={handleClick}>
@@ -149,16 +164,8 @@ export default function ResponsiveImage({
           alt={alt}
           loading={priority ? 'eager' : 'lazy'}
           decoding="async"
-          style={
-            aspectRatio
-              ? {
-                  aspectRatio: `${width} / ${height}`,
-                  width: '100%',
-                  height: 'auto',
-                }
-              : { width: '100%', height: 'auto' }
-          }
-          className="object-cover"
+          style={imgStyle}
+          className={imgClassName}
         />
       </picture>
 


### PR DESCRIPTION
## Summary

- Adds a `viewportFit` prop to `ResponsiveImage` that uses `object-contain` + `max-h-[calc(100vh-180px)]` on desktop, ensuring the full image is always visible without scrolling — for both portrait and landscape orientations
- Portrait images fit within the viewport with whitespace on the sides (Flickr-style); landscape images fill the width naturally
- Mobile behavior is unchanged (full-width, scroll to see more)
- Applied to `PhotoLayout` (photo post detail pages) and `app/page.tsx` (homepage featured image)

Closes #9

## Test plan

- [ ] Landscape photo post: image fills width, no scroll needed on 1080p desktop
- [ ] Portrait photo post: full image visible without scrolling, whitespace on sides
- [ ] Mobile: full-width display, natural scroll behavior unchanged
- [ ] Zoom overlay still works on desktop click

🤖 Generated with [Claude Code](https://claude.com/claude-code)