### PR TITLE
Add Cursor Cloud development environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+This repository is a personal static blog built with Next.js 15 (App Router), TypeScript, and Tailwind CSS. Content is authored as MDX under `content/posts/**/index.mdx`. See `README.md` and `CLAUDE.md` for full architecture, content model, and the `blog` CLI reference.
+
+## Cursor Cloud specific instructions
+
+Dependencies (`npm install`) are refreshed automatically on startup. Notes below cover non-obvious caveats for running/validating the app in this environment.
+
+### Running the app
+- Dev server: `npm run dev` (Next.js + Turbopack on http://localhost:3000). `next dev` does NOT run the `prebuild` scripts, so it starts without any network/AWS access.
+- `next.config.ts` only enables static export (`output: "export"`) when `NODE_ENV === "production"`. In dev all routes are reachable without being listed in `generateStaticParams`, and `draft: true` posts are visible (they are hidden in production builds).
+
+### Build
+- `npm run build` works offline. Its `prebuild` step runs `scripts/fetch-mastodon.js`, which calls `micah.social`; on failure it logs a warning and keeps the existing `public/mastodon.json`, so the build still succeeds. The fetch may rewrite `public/mastodon.json` — treat that as a build artifact and do not commit it.
+
+### Lint
+- `npm run lint` (`next lint`) is NOT configured in this repo and prompts for interactive ESLint setup, so it cannot run non-interactively. Lint is also not part of CI (`.github/workflows/deploy.yml` only runs `npm run build`). Use a successful `npm run build` as the primary correctness signal.
+
+### Tests
+- There are no automated tests (no test runner, no `test` script). Validate changes by running the dev server and checking pages, plus `npm run build`.
+
+### Images / AWS features are optional for local dev
+- Post images are stored in S3/CDN and are NOT in the repo, so they render as broken image placeholders locally. This is expected. Pulling them requires AWS credentials (`blog images:download --profile www`). AWS-backed features (newsletter API, image upload, analytics, SES Lambdas under `infra/`) are not needed to run or develop the site UI locally.
+
+### Content authoring caveat
+- `scripts/create-post.js` (`blog post:new`) is interactive via stdin prompts and does not work when stdin is piped/non-interactive. To create a post programmatically, write `content/posts/YYYY-MM-DD-<slug>/index.mdx` directly (frontmatter shape is in `CLAUDE.md`) and increment `content/post-counter`. The dev server hot-reloads new posts at `/posts/<slug>`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,5 +22,9 @@ Dependencies (`npm install`) are refreshed automatically on startup. Notes below
 ### Images / AWS features are optional for local dev
 - Post images are stored in S3/CDN and are NOT in the repo, so they render as broken image placeholders locally. This is expected. Pulling them requires AWS credentials (`blog images:download --profile www`). AWS-backed features (newsletter API, image upload, analytics, SES Lambdas under `infra/`) are not needed to run or develop the site UI locally.
 
+### AWS CLI
+- AWS CLI v2 is installed at `/usr/local/bin/aws` (a system dependency captured by the VM snapshot, not by `npm install`). If a fresh VM is ever missing it, reinstall with: `curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip && cd /tmp && unzip -q awscliv2.zip && sudo ./aws/install --update`.
+- This account uses AWS Identity Center (SSO). Credentials are obtained interactively per session — there are no static keys. The repo convention is the `www` profile (region `us-east-1`). First-time config: `aws configure sso --profile www`; subsequent sessions: `aws sso login --profile www`. SSO tokens are short-lived and do not survive across VMs, so expect to re-authenticate each session. Verify with `aws sts get-caller-identity --profile www`.
+
 ### Content authoring caveat
 - `scripts/create-post.js` (`blog post:new`) is interactive via stdin prompts and does not work when stdin is piped/non-interactive. To create a post programmatically, write `content/posts/YYYY-MM-DD-<slug>/index.mdx` directly (frontmatter shape is in `CLAUDE.md`) and increment `content/post-counter`. The dev server hot-reloads new posts at `/posts/<slug>`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the local development environment for this Next.js 15 static blog so Cursor Cloud agents can run, build, and develop the site, plus installs AWS CLI tooling.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering non-obvious run/build/lint/test/image caveats.
- Configures the startup update script to `npm install` (the repo's only lockfile is `package-lock.json`).
- Installs AWS CLI v2 in the VM and documents the AWS Identity Center (SSO) login flow with the `www` profile.

No application code was changed.

## Environment verification

| Check | Command | Result |
|---|---|---|
| Install deps | `npm install` | ✅ 748 packages installed |
| Build | `npm run build` | ✅ static export generated for all routes |
| Dev server | `npm run dev` | ✅ serves http://localhost:3000 (home, `/posts`, post pages return 200) |
| AWS CLI | `aws --version` | ✅ aws-cli/2.35.11 installed at `/usr/local/bin/aws` |
| Lint | `npm run lint` | ⚠️ `next lint` is unconfigured (interactive prompt) and not part of CI |
| Tests | — | ⚠️ no automated tests / test script exist in repo |

## AWS CLI / SSO

AWS CLI v2 is installed. The account uses AWS Identity Center (SSO), so credentials are obtained interactively per session (no static keys). Convention is the `www` profile (`us-east-1`): `aws configure sso --profile www` for first-time setup, `aws sso login --profile www` each session. Documented in `AGENTS.md`.

## Hello-world validation

Created a blog post (`Hello Cursor Cloud`) via the content authoring flow and confirmed it rendered live in the dev server at `/posts/hello-cursor-cloud` (title, sections, and body all rendered). The temporary post was removed afterward — no test content is committed.

[blog_dev_server_hello_world.mp4](https://cursor.com/agents/bc-d7a3b10b-a371-4bcb-adc3-07f062acbb33/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_dev_server_hello_world.mp4)

[Hello Cursor Cloud post rendered in dev server](https://cursor.com/agents/bc-d7a3b10b-a371-4bcb-adc3-07f062acbb33/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_cursor_cloud_post.webp)

Note: post images live in S3/CDN and are not in the repo, so they show as broken placeholders in local dev (expected; documented in `AGENTS.md`).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7a3b10b-a371-4bcb-adc3-07f062acbb33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7a3b10b-a371-4bcb-adc3-07f062acbb33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

