### PR TITLE
Fix newsletter CloudFormation deploy for large templates

### DIFF
--- a/.github/workflows/newsletter-deploy.yml
+++ b/.github/workflows/newsletter-deploy.yml
@@ -156,6 +156,8 @@ jobs:
           aws cloudformation deploy \
             --stack-name ${{ env.STACK_NAME }} \
             --template-file infra/newsletter.yml \
+            --s3-bucket ${{ env.ARTIFACTS_BUCKET }} \
+            --s3-prefix cloudformation \
             --region ${{ env.AWS_REGION }} \
             --capabilities CAPABILITY_NAMED_IAM \
             --parameter-overrides \
@@ -185,6 +187,8 @@ jobs:
           aws cloudformation deploy \
             --stack-name ${{ env.STACK_NAME_SECONDARY }} \
             --template-file infra/newsletter-secondary.yml \
+            --s3-bucket ${{ env.ARTIFACTS_BUCKET_SECONDARY }} \
+            --s3-prefix cloudformation \
             --region ${{ env.AWS_REGION_SECONDARY }} \
             --capabilities CAPABILITY_NAMED_IAM \
             --parameter-overrides \


### PR DESCRIPTION
## Summary

The issue #80 merge caused the newsletter deploy workflow to fail because `newsletter.yml` grew past CloudFormation's 51,200-byte inline template limit. This adds `--s3-bucket` / `--s3-prefix` to both primary and secondary stack deploy steps.

Infra from #80 was deployed manually; this prevents the same failure on future template changes.

## Test plan

- [ ] Merge and confirm newsletter deploy workflow succeeds on next template change


Made with [Cursor](https://cursor.com)