### PR TITLE
Fix ticket server secondary deploy and photo-upload secret updates

### DIFF
--- a/infra/photo-upload.yml
+++ b/infra/photo-upload.yml
@@ -107,9 +107,8 @@ Resources:
     Properties:
       Name: photo-upload-secrets
       Description: >
-        Photo upload secrets. Replace after first deploy:
+        Photo upload secrets. Populate manually after first deploy:
         {"passcode":"<upload passcode>","hmac":"<random signing key>","githubToken":"<fine-grained PAT, contents:write>","ticketsPasscode":"<ticket server passcode>"}
-      SecretString: '{"passcode":"REPLACE_ME","hmac":"REPLACE_WITH_RANDOM_KEY","githubToken":"REPLACE_WITH_GITHUB_TOKEN","ticketsPasscode":"REPLACE_WITH_TICKET_PASSCODE"}'
       Tags:
         - { Key: Project, Value: micahwalter-photo-upload }
         - { Key: ManagedBy, Value: CloudFormation }

--- a/infra/tickets-secondary.yml
+++ b/infra/tickets-secondary.yml
@@ -55,9 +55,9 @@ Resources:
         AllowHeaders: [Content-Type, Authorization]
         MaxAge: 300
       Tags:
-        - { Key: Project, Value: micahwalter-tickets }
-        - { Key: Region, Value: secondary }
-        - { Key: ManagedBy, Value: CloudFormation }
+        Project: micahwalter-tickets
+        Region: secondary
+        ManagedBy: CloudFormation
 
   TicketsApiStage:
     Type: AWS::ApiGatewayV2::Stage


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two issues discovered during production deploy of the ticket server (issue #85):

1. **`tickets-secondary.yml`** — `AWS::ApiGatewayV2::Api` requires map-style `Tags`, not array-style. The secondary stack failed CloudFormation validation in us-east-2 with `Property [Tags] expected type: JSONObject, found: JSONArray`.

2. **`photo-upload.yml`** — Removed inline `SecretString` from `PhotoUploadSecret` so stack updates do not attempt to overwrite populated secrets. The merge deploy failed because GitHub Actions lacks `secretsmanager:UpdateSecret`, and an admin redeploy would have reset live credentials to placeholders.

## Deploy status

These fixes were applied and verified live during deploy:
- Primary ticket stack (`micahwalter-tickets`, us-east-1) — deployed
- Secondary ticket stack (`micahwalter-tickets-secondary`, us-east-2) — deployed after tag fix
- Photo upload stack — redeployed with `TICKETS_API_URL` and updated Lambda code
- Counter seeded to **148**; smoke test returned **id 149**

## Testing

- `curl` auth + `/tickets/next` against `api.micahwalter.com` — pass
- CloudFormation deploy of both ticket stacks — pass
- Photo upload stack update — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3a71-8667-7242-a2e6-6b8b93d6065a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3a71-8667-7242-a2e6-6b8b93d6065a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

