### PR TITLE
Fix infra-deploy IAM: grant CloudFormation access to micahwalter-www stack

### DIFF
--- a/infra/github-actions-role.yml
+++ b/infra/github-actions-role.yml
@@ -667,6 +667,97 @@ Resources:
               - 'arn:aws:apigateway:us-east-1::/*'
               - 'arn:aws:apigateway:us-east-2::/*'
 
+  # Website infra (infra.yml / infra-secondary.yml) — used by infra-deploy.yml
+  WebsiteInfraDeployPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: GitHubActionsDeployWebsiteInfra
+      Roles:
+        - !Ref GitHubActionsRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+              - cloudformation:DescribeStackEvents
+              - cloudformation:DescribeStackResource
+              - cloudformation:DescribeStackResources
+              - cloudformation:CreateChangeSet
+              - cloudformation:ExecuteChangeSet
+              - cloudformation:DescribeChangeSet
+              - cloudformation:DeleteChangeSet
+              - cloudformation:GetTemplate
+              - cloudformation:GetTemplateSummary
+              - cloudformation:UpdateStack
+              - cloudformation:CreateStack
+            Resource:
+              - !Sub 'arn:aws:cloudformation:us-east-1:${AWS::AccountId}:stack/micahwalter-www/*'
+              - !Sub 'arn:aws:cloudformation:us-east-2:${AWS::AccountId}:stack/micahwalter-www-secondary/*'
+          - Effect: Allow
+            Action:
+              - cloudfront:DescribeFunction
+              - cloudfront:CreateFunction
+              - cloudfront:UpdateFunction
+              - cloudfront:PublishFunction
+              - cloudfront:DeleteFunction
+              - cloudfront:ListFunctions
+              - cloudfront:GetDistribution
+              - cloudfront:GetDistributionConfig
+              - cloudfront:UpdateDistribution
+              - cloudfront:CreateOriginAccessControl
+              - cloudfront:GetOriginAccessControl
+              - cloudfront:UpdateOriginAccessControl
+              - cloudfront:DeleteOriginAccessControl
+              - cloudfront:ListOriginAccessControls
+            Resource: '*'
+          - Effect: Allow
+            Action:
+              - s3:CreateBucket
+              - s3:DeleteBucket
+              - s3:ListBucket
+              - s3:GetBucketLocation
+              - s3:GetBucketPolicy
+              - s3:PutBucketPolicy
+              - s3:DeleteBucketPolicy
+              - s3:GetBucketAcl
+              - s3:PutBucketAcl
+              - s3:GetBucketCORS
+              - s3:PutBucketCORS
+              - s3:GetBucketLogging
+              - s3:PutBucketLogging
+              - s3:GetBucketVersioning
+              - s3:PutBucketVersioning
+              - s3:GetEncryptionConfiguration
+              - s3:PutEncryptionConfiguration
+              - s3:GetLifecycleConfiguration
+              - s3:PutLifecycleConfiguration
+              - s3:GetReplicationConfiguration
+              - s3:PutReplicationConfiguration
+              - s3:GetBucketPublicAccessBlock
+              - s3:PutBucketPublicAccessBlock
+              - s3:GetBucketOwnershipControls
+              - s3:PutBucketOwnershipControls
+              - s3:GetBucketTagging
+              - s3:PutBucketTagging
+            Resource:
+              - arn:aws:s3:::micahwalter-www-*
+              - arn:aws:s3:::micahwalter-www-*/*
+          - Effect: Allow
+            Action:
+              - iam:CreateRole
+              - iam:DeleteRole
+              - iam:GetRole
+              - iam:UpdateRole
+              - iam:PutRolePolicy
+              - iam:DeleteRolePolicy
+              - iam:GetRolePolicy
+              - iam:PassRole
+              - iam:TagRole
+              - iam:UntagRole
+            Resource:
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/micahwalter-www-replication-role'
+
 Outputs:
   RoleArn:
     Description: ARN of the IAM role for GitHub Actions


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After merging #91, **Deploy Infrastructure CloudFormation Stacks** failed ([run 28877414336](https://github.com/micahwalter/micahwalter-www/actions/runs/28877414336)):

```
AccessDenied: GitHubActionsDeployRole is not authorized to perform
cloudformation:DescribeStacks on stack micahwalter-www
```

The `infra-deploy.yml` workflow was added to deploy `infra/infra.yml`, but the GitHub Actions IAM role only had CloudFormation permissions for newsletter, photo-upload, and ticket stacks — not the main website stacks.

**Site deploy succeeded** in 1m59s (1007 pages, 53s build, 28s S3 sync). Only the CloudFront Function update is blocked.

## Fix

Add `GitHubActionsDeployWebsiteInfra` managed policy to `infra/github-actions-role.yml` with permissions for:

- CloudFormation on `micahwalter-www` and `micahwalter-www-secondary`
- CloudFront Functions + distributions (legacy redirect update)
- S3 buckets (`micahwalter-www-*`)
- Replication IAM role

## Deploy sequence (bootstrap)

1. **Merge this PR**
2. **Manually deploy the IAM stack** (one-time bootstrap — CI cannot update its own permissions):
   ```bash
   AWS_PROFILE=www aws cloudformation deploy \
     --stack-name micahwalter-www-github-actions \
     --template-file infra/github-actions-role.yml \
     --region us-east-1 \
     --capabilities CAPABILITY_NAMED_IAM \
     --parameter-overrides \
       HostedZoneId=<hosted-zone-id> \
       WebsiteBucketName=<website-bucket> \
       CloudFrontDistributionId=<distribution-id>
   ```
3. **Re-run** "Deploy Infrastructure CloudFormation Stacks" workflow (workflow_dispatch) to publish the CloudFront redirect function

Related to #90
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-916640cb-5dba-4559-8ea9-9220b7fd780e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-916640cb-5dba-4559-8ea9-9220b7fd780e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

