### PR TITLE
Normalize legacy post URLs in Fathom pageview tracking (Fixes #93)

### DIFF
--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -2,31 +2,47 @@
 
 ## Project Information
 - **Project Type**: Brownfield
-- **Start Date**: 2026-07-07T19:00:00Z
-- **Current Stage**: COMPLETE — Issue #90
+- **Start Date**: 2026-07-07T15:45:00Z
+- **Current Stage**: COMPLETE — Issue #93
 - **Engagement Status**: Complete — ready for merge
 
-## Active Engagement — Issue #90 (Deploy Build Optimization)
+## Active Engagement — Issue #93 (Fathom Canonical URLs)
 
-- **GitHub Issue:** [#90](https://github.com/micahwalter/micahwalter-www/issues/90)
-- **Pull Request:** [#91](https://github.com/micahwalter/micahwalter-www/pull/91)
-- **Branch:** `cursor/deploy-build-optimization-780e`
-- **Construction Summary:** `aidlc-docs/construction/issue-90-construction-summary.md`
+- **GitHub Issue:** [#93](https://github.com/micahwalter/micahwalter-www/issues/93)
+- **Branch:** `cursor/fathom-canonical-urls-000b`
+- **Requirements:** `aidlc-docs/inception/requirements/issue-93-requirements.md`
+- **Execution Plan:** `aidlc-docs/inception/plans/issue-93-execution-plan.md`
+- **Construction Summary:** `aidlc-docs/construction/issue-93-construction-summary.md`
 
-## Stage Progress — Issue #90
+## Extension Configuration
 
-### INCEPTION — complete
-### CONSTRUCTION — complete
-### OPERATIONS — infra + site deploy on merge (user/AWS)
+| Extension | Enabled | Decided At |
+|---|---|---|
+| Security Baseline | No | Requirements Analysis — analytics bug fix, no new attack surface |
+| Resiliency Baseline | No | Requirements Analysis — out of scope |
+| Property-Based Testing | No | Requirements Analysis — no test runner in repo |
 
-## Results
+## Stage Progress — Issue #93
 
-| Metric | Before | After |
-|--------|-------:|------:|
-| Static pages | ~2,295 | ~1,007 |
-| Local build | ~85s | ~31s |
+### INCEPTION
+- [x] Workspace Detection
+- [x] Reverse Engineering (reused brownfield artifacts)
+- [x] Requirements Analysis (minimal depth)
+- [x] User Stories (skipped — internal analytics accuracy)
+- [x] Workflow Planning
+- [ ] Application Design (skipped — single-component change)
+- [ ] Units Generation (skipped — single unit)
+
+### CONSTRUCTION
+- [ ] Functional Design (skipped)
+- [ ] NFR Requirements (skipped)
+- [ ] NFR Design (skipped)
+- [ ] Infrastructure Design (skipped)
+- [x] Code Generation
+- [x] Build and Test
 
 ## Prior Engagements (complete)
+- Issue #90 — Deploy build optimization
 - Issue #85 — Ticket Server
 - Issue #80 — Newsletter confirmation rate
 - Issue #71 — Photo upload

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -215,3 +215,19 @@
 **Context**: CONSTRUCTION complete; Issue #90 engagement COMPLETE.
 
 ---
+
+## Issue #93 — Initial Request
+**Timestamp**: 2026-07-07T15:32:00Z
+**User Input**: "I notice in my Fathom analytics that I see hits for both the permalink url and the date based urls. I think this is missleading as it should count as a redirect.. can we please log a github issue, and investigate why this may be happening?"
+**AI Response**: Investigated root cause (Next.js redirect pages loaded Fathom before client redirect; PR #91 CloudFront 301 partially fixes production). Created GitHub issue #93 with findings.
+**Context**: Pre-AI-DLC investigation.
+
+---
+
+## Issue #93 — AI-DLC Engagement Start
+**Timestamp**: 2026-07-07T15:45:00Z
+**User Input**: "lets use AI-DLC to document and fix this issue"
+**AI Response**: Started AI-DLC engagement on branch cursor/fathom-canonical-urls-000b. Completed Workspace Detection (brownfield, reused RE artifacts). Requirements Analysis minimal depth. Workflow Planning complete. Implemented lib/fathom-url.ts + Fathom.tsx canonical tracking. npm run build passed.
+**Context**: CONSTRUCTION complete; ready for PR.
+
+---

--- a/aidlc-docs/construction/issue-93-construction-summary.md
+++ b/aidlc-docs/construction/issue-93-construction-summary.md
@@ -1,0 +1,70 @@
+# Construction Summary — Issue #93: Fathom Canonical URL Tracking
+
+**GitHub Issue:** [#93](https://github.com/micahwalter/micahwalter-www/issues/93)  
+**Branch:** `cursor/fathom-canonical-urls-000b`
+
+## Changes Implemented
+
+### 1. `lib/fathom-url.ts` (new)
+
+Added `toFathomPagePath()` — client-side normalization that mirrors the CloudFront `StaticHTMLRoutingFunction` legacy redirect rules in `infra/infra.yml`:
+
+- `/YYYY/MM/DD/slug` → `/posts/slug`
+- `/YYYY/MM/slug` → `/posts/slug`
+- `/YYYY/slug` → `/posts/slug`
+- `/slug` → `/posts/slug` (excluding reserved root segments)
+
+Year archives (`/YYYY`) and month archives (`/YYYY/MM`) are left unchanged.
+
+### 2. `components/Fathom.tsx`
+
+Updated `trackPageview()` to report the canonical path from `toFathomPagePath()` instead of raw `usePathname()`. Also fixed query-string formatting (prepend `?` when search params are present).
+
+## How This Addresses the Issue
+
+| Layer | Behavior |
+|-------|----------|
+| **CloudFront (PR #91)** | Production legacy URLs return 301 before HTML loads — Fathom never runs on date paths |
+| **Fathom canonical (this PR)** | Defense in depth — if HTML ever loads on a legacy path (dev, regression, stale artifact), pageviews aggregate under `/posts/[slug]` |
+
+Historical Fathom data from before PR #91 will still show duplicate paths; this change prevents new duplicates from any code path that serves HTML on legacy URLs.
+
+## Verification
+
+### Automated
+
+- [x] `npm run build` — passed
+
+### Manual spot-check (`toFathomPagePath`)
+
+| Input | Output |
+|-------|--------|
+| `/2024/01/my-post` | `/posts/my-post` |
+| `/2024/01/28/my-post` | `/posts/my-post` |
+| `/2024/my-post` | `/posts/my-post` |
+| `/my-post` | `/posts/my-post` |
+| `/2024` | `/2024` |
+| `/2024/01` | `/2024/01` |
+| `/posts/my-post` | `/posts/my-post` |
+| `/about` | `/about` |
+
+### Production redirect (pre-existing, unchanged)
+
+```bash
+curl -sI https://www.micahwalter.com/2024/01/add-fathom-analytics-to-your-obsidian-publish-site
+# → 301 location: /posts/add-fathom-analytics-to-your-obsidian-publish-site
+```
+
+## Extension Compliance
+
+| Extension | Status |
+|-----------|--------|
+| Security Baseline | N/A |
+| Resiliency Baseline | N/A |
+| Property-Based Testing | N/A |
+
+## Post-Merge
+
+Site redeploy via normal `main` push will bake the updated Fathom client into the static build. No infra changes required.
+
+Fixes #93

--- a/aidlc-docs/inception/plans/issue-93-execution-plan.md
+++ b/aidlc-docs/inception/plans/issue-93-execution-plan.md
@@ -1,0 +1,71 @@
+# Execution Plan — Issue #93: Fathom Canonical URL Tracking
+
+**GitHub Issue**: [#93](https://github.com/micahwalter/micahwalter-www/issues/93)  
+**Branch**: `cursor/fathom-canonical-urls-000b`  
+**Date**: 2026-07-07  
+**Requirements**: `aidlc-docs/inception/requirements/issue-93-requirements.md`
+
+## Phase Decisions
+
+| AI-DLC Stage | Decision | Rationale |
+|--------------|----------|-----------|
+| Workspace Detection | COMPLETED | Brownfield; prior AI-DLC artifacts present |
+| Reverse Engineering | SKIP (reused) | Artifacts current from prior engagements |
+| Requirements Analysis | COMPLETED | Minimal depth — investigation done in #93 |
+| User Stories | SKIP | Internal analytics accuracy; no user personas |
+| Workflow Planning | COMPLETED | This document |
+| Application Design | SKIP | Single helper + one component change |
+| Units Generation | SKIP | Single unit |
+| Functional Design | SKIP | Pattern-matching only |
+| NFR Requirements | SKIP | Covered in requirements |
+| NFR Design | SKIP | Client-side string normalization |
+| Infrastructure Design | SKIP | CloudFront redirects already deployed |
+| Code Generation | EXECUTE | Unit 1 |
+| Build and Test | EXECUTE | `npm run build` |
+
+## Workflow Visualization
+
+```mermaid
+flowchart TD
+    Start(["Issue 93 Fathom Fix"])
+
+    subgraph INCEPTION["INCEPTION PHASE"]
+        WD["Workspace Detection<br/>COMPLETED"]
+        RE["Reverse Engineering<br/>SKIP"]
+        RA["Requirements Analysis<br/>COMPLETED"]
+        WP["Workflow Planning<br/>COMPLETED"]
+    end
+
+    subgraph CONSTRUCTION["CONSTRUCTION PHASE"]
+        CG["Code Generation<br/>Unit 1"]
+        BT["Build and Test"]
+    end
+
+    Start --> WD --> RE --> RA --> WP --> CG --> BT --> Done(["Complete"])
+
+    style WD fill:#4CAF50,color:#fff
+    style RA fill:#4CAF50,color:#fff
+    style WP fill:#4CAF50,color:#fff
+    style CG fill:#4CAF50,color:#fff
+    style BT fill:#4CAF50,color:#fff
+    style RE fill:#FFA726,color:#000
+```
+
+## Unit 1: Fathom Canonical URL Normalization
+
+| Step | Task | Files |
+|------|------|-------|
+| 1 | Add `toFathomPagePath()` mirroring CloudFront legacy redirect rules | `lib/fathom-url.ts` (new) |
+| 2 | Wire Fathom client to use canonical path in `trackPageview()` | `components/Fathom.tsx` |
+| 3 | Run production build | — |
+| 4 | Write construction summary with verification notes | `aidlc-docs/construction/issue-93-construction-summary.md` |
+
+## Verification Checklist
+
+- [ ] Unit tests via manual spot-check of `toFathomPagePath()` cases (no test runner in repo)
+- [ ] `npm run build` succeeds
+- [ ] Production CloudFront 301 still verified separately (already confirmed pre-engagement)
+
+## Extension Compliance Summary
+
+All extensions disabled — N/A for this engagement.

--- a/aidlc-docs/inception/plans/issue-93-execution-plan.md
+++ b/aidlc-docs/inception/plans/issue-93-execution-plan.md
@@ -55,16 +55,16 @@ flowchart TD
 
 | Step | Task | Files |
 |------|------|-------|
-| 1 | Add `toFathomPagePath()` mirroring CloudFront legacy redirect rules | `lib/fathom-url.ts` (new) |
-| 2 | Wire Fathom client to use canonical path in `trackPageview()` | `components/Fathom.tsx` |
-| 3 | Run production build | — |
-| 4 | Write construction summary with verification notes | `aidlc-docs/construction/issue-93-construction-summary.md` |
+| 1 | Add `toFathomPagePath()` mirroring CloudFront legacy redirect rules | `lib/fathom-url.ts` (new) | [x] |
+| 2 | Wire Fathom client to use canonical path in `trackPageview()` | `components/Fathom.tsx` | [x] |
+| 3 | Run production build | — | [x] |
+| 4 | Write construction summary with verification notes | `aidlc-docs/construction/issue-93-construction-summary.md` | [x] |
 
 ## Verification Checklist
 
-- [ ] Unit tests via manual spot-check of `toFathomPagePath()` cases (no test runner in repo)
-- [ ] `npm run build` succeeds
-- [ ] Production CloudFront 301 still verified separately (already confirmed pre-engagement)
+- [x] Unit tests via manual spot-check of `toFathomPagePath()` cases (no test runner in repo)
+- [x] `npm run build` succeeds
+- [x] Production CloudFront 301 still verified separately (already confirmed pre-engagement)
 
 ## Extension Compliance Summary
 

--- a/aidlc-docs/inception/requirements/issue-93-requirements.md
+++ b/aidlc-docs/inception/requirements/issue-93-requirements.md
@@ -1,0 +1,95 @@
+# Issue #93 — Requirements
+
+**GitHub Issue:** [#93 — Fathom analytics double-counts legacy date URLs and permalink URLs](https://github.com/micahwalter/micahwalter-www/issues/93)  
+**Branch:** `cursor/fathom-canonical-urls-000b`
+
+## Intent Analysis
+
+| Field | Value |
+|-------|-------|
+| **User request** | Document and fix misleading Fathom pageview counts where legacy date-based post URLs and canonical permalinks appear as separate hits for the same visit |
+| **Request type** | Bug fix / enhancement (analytics accuracy) |
+| **Scope estimate** | Single component — Fathom client + shared URL helper |
+| **Complexity estimate** | Simple — pattern-matching mirrors existing CloudFront redirect logic |
+
+## Problem Statement
+
+Fathom Analytics records pageviews for **both** legacy date-based URLs (e.g. `/2024/01/my-post-slug`) and canonical permalinks (`/posts/my-post-slug`) when a visitor enters via a legacy link.
+
+**Historical root cause:** Before PR #91, ~1,150 Next.js static redirect pages loaded the full app layout (including Fathom) before client-side redirect to `/posts/[slug]`, producing two pageviews per visit.
+
+**Partial fix deployed:** PR #91 added CloudFront 301 redirects at the edge so legacy URLs no longer serve HTML. New production visits via legacy paths should only record the permalink pageview after the browser follows the redirect.
+
+**Remaining gap:** `components/Fathom.tsx` tracks raw `usePathname()` with no canonical normalization. Any environment or edge case where legacy HTML loads (dev without CloudFront, stale S3 artifacts, future regressions) would still double-count. Fathom also lacks defense-in-depth aggregation under canonical paths.
+
+## Functional Requirements
+
+### FR-1: Canonical Fathom page path
+
+When Fathom records a pageview, normalize legacy post URL patterns to `/posts/[slug]` before calling `trackPageview()`.
+
+**Patterns to normalize** (must match `StaticHTMLRoutingFunction` in `infra/infra.yml`):
+
+| Pattern | Example | Canonical |
+|---------|---------|-----------|
+| `/YYYY/MM/DD/slug` | `/2024/01/28/my-post` | `/posts/my-post` |
+| `/YYYY/MM/slug` | `/2024/01/my-post` | `/posts/my-post` |
+| `/YYYY/slug` | `/2024/my-post` | `/posts/my-post` |
+| `/slug` | `/my-post` | `/posts/my-post` |
+
+**Must NOT normalize** (real archive pages):
+
+| Pattern | Example |
+|---------|---------|
+| `/YYYY` | `/2024` |
+| `/YYYY/MM` | `/2024/01` |
+
+**Reserved root segments** (must NOT normalize to `/posts/...`):  
+`about`, `colophon`, `emails`, `galleries`, `micro`, `newsletter`, `photos`, `posts`, `sketches`, `upload`, `tags`, `topics`, `page`
+
+### FR-2: Shared redirect logic
+
+Extract normalization into a reusable module (`lib/fathom-url.ts`) with comments referencing the CloudFront function so future redirect rule changes stay in sync.
+
+### FR-3: Documentation
+
+Record investigation findings, implementation, and verification steps in AI-DLC construction artifacts.
+
+## Non-Functional Requirements
+
+### NFR-1: No user-visible behavior change
+
+Analytics-only change; no layout, routing, or SEO changes required in this engagement.
+
+### NFR-2: Zero additional network requests
+
+Normalization is client-side string matching only.
+
+### NFR-3: Build correctness
+
+`npm run build` must succeed (primary validation signal for this repo).
+
+## Out of Scope
+
+| Item | Reason |
+|------|--------|
+| Fathom historical data merge | Fathom product limitation; historical duplicates remain |
+| S3 cleanup of orphaned redirect HTML | Low priority; CloudFront intercepts first (#93 optional item) |
+| Post page `<link rel="canonical">` metadata | Nice-to-have SEO; not required for Fathom fix |
+| CloudFront redirect changes | Already deployed in #90/#91 |
+
+## Acceptance Criteria
+
+- [ ] `toFathomPagePath()` normalizes all four legacy patterns to `/posts/[slug]`
+- [ ] Year and month archive paths are unchanged
+- [ ] `components/Fathom.tsx` uses canonical path for `trackPageview()`
+- [ ] `npm run build` passes
+- [ ] AI-DLC construction summary documents verification approach
+
+## Extension Compliance
+
+| Extension | Status | Rationale |
+|-----------|--------|-----------|
+| Security Baseline | N/A | No auth, data, or new endpoints |
+| Resiliency Baseline | N/A | No infrastructure changes |
+| Property-Based Testing | N/A | No test runner configured |

--- a/components/Fathom.tsx
+++ b/components/Fathom.tsx
@@ -3,6 +3,7 @@
 import { load, trackPageview } from 'fathom-client';
 import { useEffect, Suspense } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
+import { toFathomPagePath } from '@/lib/fathom-url';
 
 function TrackPageView() {
   const pathname = usePathname();
@@ -16,8 +17,10 @@ function TrackPageView() {
 
   useEffect(() => {
     if (!pathname) return;
+    const query = searchParams?.toString();
+    const canonicalPath = toFathomPagePath(pathname);
     trackPageview({
-      url: pathname + (searchParams?.toString() ?? ''),
+      url: canonicalPath + (query ? `?${query}` : ''),
       referrer: document.referrer,
     });
   }, [pathname, searchParams]);

--- a/lib/fathom-url.ts
+++ b/lib/fathom-url.ts
@@ -1,0 +1,85 @@
+/**
+ * Canonical page paths for Fathom Analytics.
+ *
+ * Mirrors legacy post redirect rules in infra/infra.yml StaticHTMLRoutingFunction
+ * so pageviews aggregate under /posts/[slug] even if HTML loads on a legacy path.
+ */
+
+const RESERVED_SEGMENTS = new Set([
+  "about",
+  "colophon",
+  "emails",
+  "galleries",
+  "micro",
+  "newsletter",
+  "photos",
+  "posts",
+  "sketches",
+  "upload",
+  "tags",
+  "topics",
+  "page",
+]);
+
+function isValidMonth(month: string): boolean {
+  if (!/^\d{2}$/.test(month)) return false;
+  const n = parseInt(month, 10);
+  return n >= 1 && n <= 12;
+}
+
+function isFourDigitYear(segment: string): boolean {
+  return /^\d{4}$/.test(segment);
+}
+
+function isTwoDigit(segment: string): boolean {
+  return /^\d{2}$/.test(segment);
+}
+
+/**
+ * Map a pathname to the canonical Fathom page path.
+ * Archive pages (/YYYY, /YYYY/MM) and reserved routes are unchanged.
+ */
+export function toFathomPagePath(pathname: string): string {
+  let path = pathname;
+  if (path.length > 1 && path.endsWith("/")) {
+    path = path.slice(0, -1);
+  }
+
+  const parts = path.split("/").filter(Boolean);
+  const count = parts.length;
+
+  if (count === 0) {
+    return pathname;
+  }
+
+  // /YYYY/MM/DD/slug
+  if (
+    count === 4 &&
+    isFourDigitYear(parts[0]) &&
+    isValidMonth(parts[1]) &&
+    isTwoDigit(parts[2])
+  ) {
+    return `/posts/${parts[3]}`;
+  }
+
+  // /YYYY/MM/slug — month archives are only /YYYY/MM (count === 2)
+  if (count === 3 && isFourDigitYear(parts[0]) && isValidMonth(parts[1])) {
+    return `/posts/${parts[2]}`;
+  }
+
+  // /YYYY/slug where slug is not a month number
+  if (count === 2 && isFourDigitYear(parts[0]) && !isValidMonth(parts[1])) {
+    return `/posts/${parts[1]}`;
+  }
+
+  // /slug at site root (legacy WordPress-style permalinks)
+  if (
+    count === 1 &&
+    !isFourDigitYear(parts[0]) &&
+    !RESERVED_SEGMENTS.has(parts[0])
+  ) {
+    return `/posts/${parts[0]}`;
+  }
+
+  return pathname;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes misleading Fathom analytics where legacy date-based post URLs and canonical permalinks appeared as separate pageviews for the same visit.

- Adds `lib/fathom-url.ts` with `toFathomPagePath()` — mirrors CloudFront legacy redirect rules from `infra/infra.yml`
- Updates `components/Fathom.tsx` to report canonical `/posts/[slug]` paths to `trackPageview()`
- Fixes query-string formatting in Fathom tracking (prepend `?` when search params present)

## Context

**Historical root cause:** Before PR #91, ~1,150 Next.js static redirect pages loaded the full app layout (including Fathom) before client-side redirect, producing two pageviews per legacy-URL visit.

**Production mitigation (already deployed):** CloudFront returns 301 for legacy URLs before HTML loads, so Fathom should not run on date paths in production.

**This PR:** Defense in depth — if HTML ever loads on a legacy path (dev, regression, stale artifact), pageviews aggregate under the canonical permalink.

Historical Fathom data from before PR #91 will still show duplicate paths.

## AI-DLC Artifacts

- Requirements: `aidlc-docs/inception/requirements/issue-93-requirements.md`
- Execution plan: `aidlc-docs/inception/plans/issue-93-execution-plan.md`
- Construction summary: `aidlc-docs/construction/issue-93-construction-summary.md`

## Verification

- [x] `npm run build` passes
- [x] Manual spot-check of `toFathomPagePath()` for all legacy patterns + archive/reserved paths
- [x] Production CloudFront 301 for legacy URLs confirmed (pre-existing)

Fixes #93
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b8b378f-f54d-482b-9d67-97ddfa5c000b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b8b378f-f54d-482b-9d67-97ddfa5c000b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

