### PR TITLE
Add git-based commenting via giscus

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,9 @@ jobs:
           NEXT_PUBLIC_FATHOM_SITE_ID: ${{ secrets.NEXT_PUBLIC_FATHOM_SITE_ID }}
           NEXT_PUBLIC_NEWSLETTER_API_URL: ${{ secrets.NEXT_PUBLIC_NEWSLETTER_API_URL }}
           NEXT_PUBLIC_PHOTO_API_URL: ${{ secrets.NEXT_PUBLIC_PHOTO_API_URL }}
+          NEXT_PUBLIC_GISCUS_CATEGORY: ${{ secrets.NEXT_PUBLIC_GISCUS_CATEGORY }}
+          NEXT_PUBLIC_GISCUS_CATEGORY_ID: ${{ secrets.NEXT_PUBLIC_GISCUS_CATEGORY_ID }}
+          NEXT_PUBLIC_GISCUS_REPO_ID: ${{ secrets.NEXT_PUBLIC_GISCUS_REPO_ID }}
 
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,23 @@ Fathom Analytics is added via `components/Fathom.tsx`, included in `app/layout.t
 - **Local dev**: add `NEXT_PUBLIC_FATHOM_SITE_ID=<id>` to `.env.local`
 - **Production**: set `NEXT_PUBLIC_FATHOM_SITE_ID` as a GitHub Actions secret (it is baked into the static build at CI time)
 
+## Comments (giscus)
+
+Git-based commenting via [giscus](https://giscus.app), which maps each post to a GitHub Discussion on this repo. Client-side only (`components/Comments.tsx` injects the `giscus.app/client.js` script), so it works with `output: "export"`. Wired into both `PostLayout.tsx` and `PhotoLayout.tsx`, below the "Edit on GitHub" link.
+
+**One-time setup:**
+1. Enable Discussions on the repo (Settings → General → Features)
+2. Create a locked "Announcement"-format category (e.g. `Comments`) so only giscus opens threads
+3. Install the giscus GitHub App: https://github.com/apps/giscus
+4. Run the configurator at https://giscus.app with mapping = `pathname` to get the repo ID and category ID
+
+**Env vars** (baked into the static build, same pattern as Fathom):
+- `NEXT_PUBLIC_GISCUS_CATEGORY` — category name (e.g. `Comments`)
+- `NEXT_PUBLIC_GISCUS_CATEGORY_ID` — from the giscus configurator
+- `NEXT_PUBLIC_GISCUS_REPO_ID` — from the giscus configurator
+
+Set locally in `.env.local` and in production as GitHub Actions secrets (see `.github/workflows/deploy.yml`). If unset, `Comments` renders an empty container and no script loads.
+
 ## Custom Domain
 
 The site is live at `https://www.micahwalter.com`. Infra managed in `infra/infra.yml`:

--- a/README.md
+++ b/README.md
@@ -477,6 +477,32 @@ The API and uploads bucket allow CORS from `http://localhost:3000` as well as pr
 
 See `CLAUDE.md` → **Photo Upload (Web)** for the full runbook, manual deploy commands, and gotchas.
 
+## Comments
+
+Blog posts and photos get a comment thread powered by [giscus](https://giscus.app), which stores comments as GitHub Discussions on this repo — no database, no server. The widget loads client-side via a `<script>` tag (`components/Comments.tsx`), so it works fine from a static export.
+
+### One-time setup
+
+1. Enable **Discussions** on this repo: Settings → General → Features → check "Discussions".
+2. Create a discussion category dedicated to comments (Discussions tab → Edit categories → New category), e.g. named `Comments`, format "Announcement" (locked so only giscus can start threads).
+3. Install the [giscus app](https://github.com/apps/giscus) on this repo.
+4. Run the [giscus configurator](https://giscus.app), enter this repo, and choose:
+   - **Page ↔ Discussions Mapping**: `pathname`
+   - **Discussion Category**: the category created in step 2
+5. Copy the `data-repo-id` and `data-category-id` values it generates and set them as GitHub Actions secrets `NEXT_PUBLIC_GISCUS_REPO_ID` and `NEXT_PUBLIC_GISCUS_CATEGORY_ID` (plus `NEXT_PUBLIC_GISCUS_CATEGORY` for the category name), then redeploy the site so they're baked into the static build.
+
+### Local development
+
+Add to `.env.local`:
+
+```bash
+NEXT_PUBLIC_GISCUS_CATEGORY=Comments
+NEXT_PUBLIC_GISCUS_CATEGORY_ID=your-giscus-category-id
+NEXT_PUBLIC_GISCUS_REPO_ID=your-github-repo-id
+```
+
+Until these are set, `Comments` renders an empty container (no script is injected).
+
 ## Image Workflow
 
 This project uses a dual-storage system for images to support multi-machine workflows without bloating the Git repository.
@@ -624,6 +650,9 @@ npm run images:dev       # Optimize + copy to public/ for dev
 | `NEXT_PUBLIC_FATHOM_SITE_ID` | Fathom Analytics site ID (baked in at build time) |
 | `NEXT_PUBLIC_NEWSLETTER_API_URL` | Newsletter API Gateway base URL (baked in at build time) |
 | `NEXT_PUBLIC_PHOTO_API_URL` | Photo upload API base URL (baked in at build time; required for `/upload`) |
+| `NEXT_PUBLIC_GISCUS_CATEGORY` | giscus Discussions category name, e.g. `Comments` (baked in at build time) |
+| `NEXT_PUBLIC_GISCUS_CATEGORY_ID` | giscus Discussions category ID from the [giscus configurator](https://giscus.app) (baked in at build time) |
+| `NEXT_PUBLIC_GISCUS_REPO_ID` | GitHub repo ID from the [giscus configurator](https://giscus.app) (baked in at build time) |
 
 **Local Development:**
 Create `.env.local`:
@@ -632,6 +661,9 @@ Create `.env.local`:
 NEXT_PUBLIC_FATHOM_SITE_ID=your-fathom-site-id
 NEXT_PUBLIC_NEWSLETTER_API_URL=https://api.micahwalter.com/newsletter
 NEXT_PUBLIC_PHOTO_API_URL=https://api.micahwalter.com/photos
+NEXT_PUBLIC_GISCUS_CATEGORY=Comments
+NEXT_PUBLIC_GISCUS_CATEGORY_ID=your-giscus-category-id
+NEXT_PUBLIC_GISCUS_REPO_ID=your-github-repo-id
 ```
 
 ## Build Process
@@ -1192,6 +1224,7 @@ Defined in `tailwind.config.ts`:
 - ✅ Draft post support (dev vs production)
 - ✅ Themed 404 page (`app/not-found.tsx`)
 - ✅ Fathom Analytics (privacy-first, page-view tracking)
+- ✅ Git-based commenting via [giscus](https://giscus.app) (GitHub Discussions)
 
 ### Photo Archive Features
 - ✅ Unified content system (photos as posts with `type: photo`)

--- a/components/Comments.tsx
+++ b/components/Comments.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+const GISCUS_REPO = 'micahwalter/micahwalter-www';
+
+export default function Comments() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current || ref.current.hasChildNodes()) return;
+
+    const repoId = process.env.NEXT_PUBLIC_GISCUS_REPO_ID;
+    const category = process.env.NEXT_PUBLIC_GISCUS_CATEGORY;
+    const categoryId = process.env.NEXT_PUBLIC_GISCUS_CATEGORY_ID;
+
+    if (!repoId || !category || !categoryId) return;
+
+    const script = document.createElement('script');
+    script.src = 'https://giscus.app/client.js';
+    script.async = true;
+    script.crossOrigin = 'anonymous';
+    script.setAttribute('data-repo', GISCUS_REPO);
+    script.setAttribute('data-repo-id', repoId);
+    script.setAttribute('data-category', category);
+    script.setAttribute('data-category-id', categoryId);
+    script.setAttribute('data-mapping', 'pathname');
+    script.setAttribute('data-strict', '0');
+    script.setAttribute('data-reactions-enabled', '1');
+    script.setAttribute('data-emit-metadata', '0');
+    script.setAttribute('data-input-position', 'top');
+    script.setAttribute('data-theme', 'light');
+    script.setAttribute('data-lang', 'en');
+
+    ref.current.appendChild(script);
+  }, []);
+
+  return <div ref={ref} className="mt-12 pt-6 border-t border-gray/20" />;
+}

--- a/components/PhotoLayout.tsx
+++ b/components/PhotoLayout.tsx
@@ -3,6 +3,7 @@ import { format } from "date-fns";
 import type { Post } from "@/lib/content";
 import { CoverImage } from "./ResponsiveImage";
 import ExifDisplay from "./ExifDisplay";
+import Comments from "./Comments";
 
 interface PhotoLayoutProps {
   post: Post;
@@ -96,6 +97,9 @@ export default function PhotoLayout({ post, children }: PhotoLayoutProps) {
               Edit on GitHub →
             </a>
           </div>
+
+          {/* Comments */}
+          <Comments />
         </div>
 
         {/* EXIF Sidebar (1/3 width on desktop) */}

--- a/components/PostLayout.tsx
+++ b/components/PostLayout.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { format } from "date-fns";
 import type { Post } from "@/lib/content";
 import { CoverImage } from "./ResponsiveImage";
+import Comments from "./Comments";
 
 interface PostLayoutProps {
   post: Post;
@@ -91,6 +92,9 @@ export default function PostLayout({ post, children }: PostLayoutProps) {
           Edit on GitHub →
         </a>
       </div>
+
+      {/* Comments */}
+      <Comments />
     </article>
   );
 }


### PR DESCRIPTION
Closes #59. Adds a client-side Comments component that loads the
giscus widget (backed by GitHub Discussions) on blog posts and
photos, gated behind NEXT_PUBLIC_GISCUS_* env vars so it no-ops
until the repo's Discussions/giscus app are configured.