### PR TITLE
Pin OIDC deploy role trust to main

### DIFF
--- a/infra/github-actions-role.yml
+++ b/infra/github-actions-role.yml
@@ -65,8 +65,8 @@ Resources:
             Condition:
               StringEquals:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
-              StringLike:
-                token.actions.githubusercontent.com:sub: !Sub 'repo:${GitHubOrg}/${GitHubRepo}:*'
+                # Only workflows running on main may assume this role (Phase 4 / micahwalter/aws#35).
+                token.actions.githubusercontent.com:sub: !Sub 'repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/main'
       Policies:
         - PolicyName: DeployToS3AndCloudFront
           PolicyDocument:


### PR DESCRIPTION
## Summary
- Tighten `GitHubActionsDeployRole` trust from `repo:micahwalter/micahwalter-www:*` to exact `ref:refs/heads/main`
- Aligns with Phase 4 Wave B ([micahwalter/aws#35](https://github.com/micahwalter/aws/issues/35))
- Companion: PR ruleset already active on `main` (require PR, 0 approvals)

## After merge
Redeploy the IAM stack (not covered by the usual app deploy workflows):

```bash
aws cloudformation deploy \
  --stack-name micahwalter-www-github-actions \
  --template-file infra/github-actions-role.yml \
  --capabilities CAPABILITY_NAMED_IAM \
  --parameter-overrides \
    WebsiteBucketName=micahwalter-www-website \
    CloudFrontDistributionId=E1SZIKPZ79BHDU \
    HostedZoneId=Z05804121WRFHZZEYWGT5
```

Then confirm a `main` deploy workflow can still assume the role; a feature-branch `workflow_dispatch` should fail assume.

## Test plan
- [ ] Review trust condition change in `infra/github-actions-role.yml`
- [ ] After merge + stack deploy: green site/infra/newsletter/tickets/photo-upload workflow on `main`
- [ ] Optional: confirm non-main OIDC assume is denied


Made with [Cursor](https://cursor.com)