### PR TITLE
Add photo post: IMG 1983 (#170)

### DIFF
--- a/content/posts/2026-07-16-photo-img-1983/index.md
+++ b/content/posts/2026-07-16-photo-img-1983/index.md
@@ -1,0 +1,18 @@
+---
+type: photo
+id: 170
+title: "IMG 1983"
+publishedAt: "2026-07-16"
+excerpt: "Photo taken with Apple iPhone 17 Pro Max"
+category: "Photography"
+tags: ["photography"]
+coverImage: "./photo.jpeg"
+camera: "Apple iPhone 17 Pro Max"
+lens: "iPhone 17 Pro Max back triple camera 6.765mm f/1.78"
+aperture: "f/1.8"
+shutterSpeed: "1/2400"
+iso: "80"
+focalLength: "6.764999866370901 mm"
+dateTaken: "2026-07-15 08:40:36"
+draft: false
+---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Recovers today's phone upload (**IMG 1983**) that never made it onto the site.

The photo-upload Lambda processed the image successfully (variants + original are already in `micahwalter-www-images` under `2026-07-16-photo-img-1983/`), but committing to `main` failed after the July 15 ruleset **Protect main — require PR** went active. The Lambda still pushes directly to `main` with a PAT.

This PR adds the missing `content/posts/2026-07-16-photo-img-1983/index.md` (post id **170**) so the normal deploy can publish it.

## Details

- Source file: `IMG_1983.jpeg` (still in `micahwalter-photo-uploads/uploads/incoming/…`)
- Featured: no
- EXIF: Apple iPhone 17 Pro Max, taken 2026-07-15 08:40:36

## Follow-up (not in this PR)

Phone uploads will keep failing until either:
1. The photo-upload PAT/user is added as a bypass actor on ruleset `18995981`, or
2. The Lambda is changed to open a PR instead of pushing to `main`

## Test plan

- [ ] Merge this PR
- [ ] Confirm Deploy to AWS runs on `main`
- [ ] Check `/posts/170` and Recent Photos on the homepage
- [ ] Optionally delete the stuck incoming S3 object after merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efd0a479-2102-4f38-a13d-35515a536884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efd0a479-2102-4f38-a13d-35515a536884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

