### PR TITLE
Photo metadata DynamoDB data plane (U1) — #103 / #104

### DIFF
--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -3,14 +3,14 @@
 ## Project Information
 - **Project Type**: Brownfield
 - **Start Date**: 2026-07-16T15:24:00Z
-- **Current Stage**: CONSTRUCTION — U1 Code Generation (plan approval gate)
+- **Current Stage**: CONSTRUCTION — U1 Code Generation (approval gate after implementation)
 - **Engagement Status**: In progress
 - **Branch:** `cursor/photo-metadata-dynamodb-be02`
 
 ## Active Engagement — Issues #103 / #104
-- **Current unit:** U1 Photo data plane
-- **U1 design stages:** FD / NFR Req / NFR Design / Infra Design — approved
-- **U1 Code Generation Plan:** `aidlc-docs/construction/plans/u1-photo-data-plane-code-generation-plan.md`
+- **Current unit:** U1 Photo data plane — **implementation complete, awaiting Continue**
+- **Code summary:** `aidlc-docs/construction/u1-photo-data-plane/code/code-summary.md`
+- **Next after U1 CG approve:** U2 Enrichment (Functional Design…) or user may request deploy smoke first
 
 ## Stage Progress
 
@@ -22,7 +22,7 @@
 - [x] NFR Requirements (approved)
 - [x] NFR Design (approved)
 - [x] Infrastructure Design (approved)
-- [ ] Code Generation (plan filed; awaiting approval)
+- [x] Code Generation (implemented; awaiting Continue)
 
 ### CONSTRUCTION — U2–U7 + Build and Test
-- [ ] Pending
+- [ ] Pending (Build and Test after all units)

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -3,47 +3,26 @@
 ## Project Information
 - **Project Type**: Brownfield
 - **Start Date**: 2026-07-16T15:24:00Z
-- **Current Stage**: CONSTRUCTION — U1 Functional Design (awaiting plan answers)
+- **Current Stage**: CONSTRUCTION — U1 Code Generation (plan approval gate)
 - **Engagement Status**: In progress
-- **Last commit**: `9d75685` — docs(aidlc): inception for photo metadata DynamoDB migration (#103/#104)
+- **Branch:** `cursor/photo-metadata-dynamodb-be02`
 
 ## Active Engagement — Issues #103 / #104
-
-- **Branch:** `cursor/photo-metadata-dynamodb-be02`
-- **Units:** U1→U7 sequential; **current: U1 Photo data plane**
-- **U1 Functional Design Plan:** `aidlc-docs/construction/plans/u1-photo-data-plane-functional-design-plan.md`
-
-## Extension Configuration
-
-| Extension | Enabled |
-|---|---|
-| Security Baseline | No |
-| Resiliency Baseline | No |
-| Property-Based Testing | No |
+- **Current unit:** U1 Photo data plane
+- **U1 design stages:** FD / NFR Req / NFR Design / Infra Design — approved
+- **U1 Code Generation Plan:** `aidlc-docs/construction/plans/u1-photo-data-plane-code-generation-plan.md`
 
 ## Stage Progress
 
 ### INCEPTION
-- [x] Workspace Detection
-- [x] Reverse Engineering
-- [x] Requirements Analysis
-- [x] User Stories
-- [x] Workflow Planning
-- [x] Application Design
-- [x] Units Generation (approved)
+- [x] All inception stages approved
 
 ### CONSTRUCTION — U1 Photo data plane
-- [ ] Functional Design (plan filed; awaiting answers)
-- [ ] NFR Requirements
-- [ ] NFR Design
-- [ ] Infrastructure Design
-- [ ] Code Generation
+- [x] Functional Design (approved)
+- [x] NFR Requirements (approved)
+- [x] NFR Design (approved)
+- [x] Infrastructure Design (approved)
+- [ ] Code Generation (plan filed; awaiting approval)
 
-### CONSTRUCTION — U2–U7
-- [ ] Pending after U1
-
-### CONSTRUCTION — Final
-- [ ] Build and Test
-
-### OPERATIONS
-- [ ] Placeholder
+### CONSTRUCTION — U2–U7 + Build and Test
+- [ ] Pending

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -3,27 +3,25 @@
 ## Project Information
 - **Project Type**: Brownfield
 - **Start Date**: 2026-07-16T15:24:00Z
-- **Current Stage**: INCEPTION — Units Generation (approval gate)
+- **Current Stage**: CONSTRUCTION — U1 Functional Design (awaiting plan answers)
 - **Engagement Status**: In progress
+- **Last commit**: `9d75685` — docs(aidlc): inception for photo metadata DynamoDB migration (#103/#104)
 
-## Active Engagement — Issues #103 / #104 (Photo Metadata → DynamoDB + Dynamic Serving)
+## Active Engagement — Issues #103 / #104
 
-- **GitHub Issues:** [#103](https://github.com/micahwalter/micahwalter-www/issues/103), [#104](https://github.com/micahwalter/micahwalter-www/issues/104)
 - **Branch:** `cursor/photo-metadata-dynamodb-be02`
-- **Requirements / Stories / App Design / Execution Plan:** approved
-- **Units Plan:** `aidlc-docs/inception/plans/issue-103-unit-of-work-plan.md` (approved)
-- **Units:** `unit-of-work.md`, `unit-of-work-dependency.md`, `unit-of-work-story-map.md` (awaiting approval)
-- **Next after Units approval:** CONSTRUCTION — Unit U1 (Functional Design → … → Code Generation), sequential through U7, then Build and Test
+- **Units:** U1→U7 sequential; **current: U1 Photo data plane**
+- **U1 Functional Design Plan:** `aidlc-docs/construction/plans/u1-photo-data-plane-functional-design-plan.md`
 
 ## Extension Configuration
 
-| Extension | Enabled | Decided At |
-|---|---|---|
-| Security Baseline | No | Requirements Analysis |
-| Resiliency Baseline | No | Requirements Analysis — multi-region via NFR-3 / U7 |
-| Property-Based Testing | No | Requirements Analysis |
+| Extension | Enabled |
+|---|---|
+| Security Baseline | No |
+| Resiliency Baseline | No |
+| Property-Based Testing | No |
 
-## Stage Progress — Issues #103 / #104
+## Stage Progress
 
 ### INCEPTION
 - [x] Workspace Detection
@@ -32,18 +30,20 @@
 - [x] User Stories
 - [x] Workflow Planning
 - [x] Application Design
-- [x] Units Generation (artifacts written; awaiting approval)
+- [x] Units Generation (approved)
 
-### CONSTRUCTION (per unit U1→U7, then once)
-- [ ] Functional Design — EXECUTE as needed per unit
-- [ ] NFR Requirements — EXECUTE as needed per unit
-- [ ] NFR Design — EXECUTE as needed per unit
-- [ ] Infrastructure Design — EXECUTE as needed per unit
-- [ ] Code Generation — EXECUTE
-- [ ] Build and Test — EXECUTE
+### CONSTRUCTION — U1 Photo data plane
+- [ ] Functional Design (plan filed; awaiting answers)
+- [ ] NFR Requirements
+- [ ] NFR Design
+- [ ] Infrastructure Design
+- [ ] Code Generation
+
+### CONSTRUCTION — U2–U7
+- [ ] Pending after U1
+
+### CONSTRUCTION — Final
+- [ ] Build and Test
 
 ### OPERATIONS
-- [ ] Operations — PLACEHOLDER
-
-## Prior Engagements (complete)
-- Issue #100, #93, #90, #85, #80, #71
+- [ ] Placeholder

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -2,48 +2,48 @@
 
 ## Project Information
 - **Project Type**: Brownfield
-- **Start Date**: 2026-07-07T15:45:00Z
-- **Current Stage**: COMPLETE — Issue #100
-- **Engagement Status**: Complete — ready for PR
+- **Start Date**: 2026-07-16T15:24:00Z
+- **Current Stage**: INCEPTION — Units Generation (approval gate)
+- **Engagement Status**: In progress
 
-## Active Engagement — Issue #100 (Recent Photos Section on Homepage)
+## Active Engagement — Issues #103 / #104 (Photo Metadata → DynamoDB + Dynamic Serving)
 
-- **GitHub Issue:** [#100](https://github.com/micahwalter/micahwalter-www/issues/100)
-- **Branch:** `claude/ai-dlc-implementation-plan-2ltytn`
-- **Requirements:** `aidlc-docs/inception/requirements/issue-100-requirements.md`
-- **Execution Plan:** `aidlc-docs/inception/plans/issue-100-execution-plan.md`
-- **Construction Summary:** `aidlc-docs/construction/issue-100-construction-summary.md`
+- **GitHub Issues:** [#103](https://github.com/micahwalter/micahwalter-www/issues/103), [#104](https://github.com/micahwalter/micahwalter-www/issues/104)
+- **Branch:** `cursor/photo-metadata-dynamodb-be02`
+- **Requirements / Stories / App Design / Execution Plan:** approved
+- **Units Plan:** `aidlc-docs/inception/plans/issue-103-unit-of-work-plan.md` (approved)
+- **Units:** `unit-of-work.md`, `unit-of-work-dependency.md`, `unit-of-work-story-map.md` (awaiting approval)
+- **Next after Units approval:** CONSTRUCTION — Unit U1 (Functional Design → … → Code Generation), sequential through U7, then Build and Test
 
 ## Extension Configuration
 
 | Extension | Enabled | Decided At |
 |---|---|---|
-| Security Baseline | No | Requirements Analysis — presentational homepage change, no new attack surface |
-| Resiliency Baseline | No | Requirements Analysis — out of scope |
-| Property-Based Testing | No | Requirements Analysis — no test runner in repo |
+| Security Baseline | No | Requirements Analysis |
+| Resiliency Baseline | No | Requirements Analysis — multi-region via NFR-3 / U7 |
+| Property-Based Testing | No | Requirements Analysis |
 
-## Stage Progress — Issue #100
+## Stage Progress — Issues #103 / #104
 
 ### INCEPTION
 - [x] Workspace Detection
-- [x] Reverse Engineering (reused brownfield artifacts)
-- [x] Requirements Analysis (standard depth — design decision flagged)
-- [x] User Stories (skipped — simple homepage teaser addition)
+- [x] Reverse Engineering
+- [x] Requirements Analysis
+- [x] User Stories
 - [x] Workflow Planning
-- [ ] Application Design (skipped — single-component change)
-- [ ] Units Generation (skipped — single unit)
+- [x] Application Design
+- [x] Units Generation (artifacts written; awaiting approval)
 
-### CONSTRUCTION
-- [ ] Functional Design (skipped — no business logic)
-- [ ] NFR Requirements (skipped — covered in requirements)
-- [ ] NFR Design (skipped)
-- [ ] Infrastructure Design (skipped)
-- [x] Code Generation
-- [x] Build and Test
+### CONSTRUCTION (per unit U1→U7, then once)
+- [ ] Functional Design — EXECUTE as needed per unit
+- [ ] NFR Requirements — EXECUTE as needed per unit
+- [ ] NFR Design — EXECUTE as needed per unit
+- [ ] Infrastructure Design — EXECUTE as needed per unit
+- [ ] Code Generation — EXECUTE
+- [ ] Build and Test — EXECUTE
+
+### OPERATIONS
+- [ ] Operations — PLACEHOLDER
 
 ## Prior Engagements (complete)
-- Issue #93 — Fathom canonical URL tracking
-- Issue #90 — Deploy build optimization
-- Issue #85 — Ticket Server
-- Issue #80 — Newsletter confirmation rate
-- Issue #71 — Photo upload
+- Issue #100, #93, #90, #85, #80, #71

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -571,3 +571,11 @@
 **Context**: CONSTRUCTION — U1 Code Generation plan approval gate.
 
 ---
+
+## Issues #103 / #104 — U1 Code Gen Approved + Push + Implementation Start
+**Timestamp**: 2026-07-16T19:09:00Z
+**User Input**: "yes please push these commit to the remote branch and begin implementation"
+**AI Response**: Pushing cursor/photo-metadata-dynamodb-be02 to origin. Code generation plan approved. Starting Part 2 implementation of U1 photo data plane.
+**Context**: CONSTRUCTION — U1 Code Generation Part 2.
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -588,3 +588,11 @@
 **Context**: CONSTRUCTION — U1 Code Generation approval gate.
 
 ---
+
+## Issues #103 / #104 — PR Opened
+**Timestamp**: 2026-07-16T19:16:00Z
+**User Input**: "ok lets open a PR"
+**AI Response**: Created draft PR for branch cursor/photo-metadata-dynamodb-be02 against main covering U1 photo DynamoDB data plane + AI-DLC docs for #103/#104.
+**Context**: PR created; U1 CG still awaiting Continue to U2 if user wants to proceed in-branch.
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -247,3 +247,202 @@
 **Context**: CONSTRUCTION complete; Issue #100 engagement COMPLETE.
 
 ---
+
+## Issues #103 / #104 — AI-DLC Engagement Start
+**Timestamp**: 2026-07-16T15:24:00Z
+**User Input**: "ok lets use AI-DLC to capture this idea and turn it into reality.."
+**AI Response**: Started new AI-DLC engagement for photo metadata DynamoDB migration (#103) + additional requirements (#104). Displayed welcome message. Created branch `cursor/photo-metadata-dynamodb-be02`. Workspace Detection: brownfield; site-wide RE (2026-06-24) stale for photo-upload/tickets — produced focused supplement `photo-subsystem.md`. Presenting Reverse Engineering for approval before Requirements Analysis.
+**Context**: INCEPTION — Workspace Detection complete; Reverse Engineering approval gate.
+
+---
+
+## Issues #103 / #104 — Reverse Engineering Approved
+**Timestamp**: 2026-07-16T15:29:00Z
+**User Input**: "approve and continue"
+**AI Response**: Reverse Engineering approved. Proceeding to Requirements Analysis (comprehensive depth). Creating requirement-verification-questions.md with functional decisions from #103/#104 plus extension opt-ins. Stopping at Requirements Analysis answer gate.
+**Context**: INCEPTION — Requirements Analysis; awaiting user answers.
+
+---
+
+## Issues #103 / #104 — Requirements Answers Received
+**Timestamp**: 2026-07-16T15:53:00Z
+**User Input**: "ok done with Q/A feedback"
+**AI Response**: Reading issue-103-requirement-verification-questions.md answers; validating completeness and contradictions before generating requirements.md.
+**Context**: INCEPTION — Requirements Analysis; processing answers.
+
+---
+
+## Issues #103 / #104 — Requirements Clarification Needed
+**Timestamp**: 2026-07-16T15:54:00Z
+**User Input**: "(answers in issue-103-requirement-verification-questions.md — Q1=A, Q2=A, Q3=B, Q4=A, Q5=B, Q6=B, Q7=A, Q8=B+city/country tags, Q9=B, Q10=B, Q11=B+how manage, Q12=A, Q13=B, Q14=B+multi-region, Q15=C)"
+**AI Response**: Detected ambiguities on gallery management (Q11) and country/city tagging (Q8). Created issue-103-clarification-questions.md. Stopping at clarification gate.
+**Context**: INCEPTION — Requirements Analysis; awaiting clarification answers.
+
+---
+
+## Issues #103 / #104 — Clarifications Received / Requirements Drafted
+**Timestamp**: 2026-07-16T15:59:00Z
+**User Input**: "done with clarifications"
+**AI Response**: Clarifications: gallery admin UI (A); reverse-geocode city/country into tags (A). Generated issue-103-requirements.md (full cutover, hybrid client/API, /photos/<id>, multi-upload, single caption field, AI tags+edit UI, static fuzzed map, galleries in DynamoDB with admin UI, live search + scheduled feeds, multi-region NFR). Extensions all disabled per answers. Presenting Requirements Analysis completion for approval. Next stage if approved: User Stories.
+**Context**: INCEPTION — Requirements Analysis approval gate.
+
+---
+
+## Issues #103 / #104 — Requirements Approved
+**Timestamp**: 2026-07-16T16:02:00Z
+**User Input**: "approve and continue"
+**AI Response**: Requirements approved. Proceeding to User Stories. Performing intelligent assessment (execute — new user-facing upload/edit/gallery/browse flows). Starting Part 1 story planning with questions.
+**Context**: INCEPTION — User Stories Part 1 Planning.
+
+---
+
+## Issues #103 / #104 — Story Plan Answers Received
+**Timestamp**: 2026-07-16T17:21:00Z
+**User Input**: "ok I tried to answer the questions as best I could"
+**AI Response**: Reading issue-103-story-generation-plan.md answers; validating for ambiguities before plan approval / generation.
+**Context**: INCEPTION — User Stories Part 1; validating answers.
+
+---
+
+## Issues #103 / #104 — Story Plan Approval Prompt
+**Timestamp**: 2026-07-16T17:22:00Z
+**User Input**: "(pending)"
+**AI Response**: Story plan answers validated (Q1=A, Q2=B, Q3=A, Q4=A, Q5=A, Q6=A). No ambiguities. Presenting story generation plan for explicit approval before Part 2 generation.
+**Approval Prompt**: "Please approve the story generation plan at aidlc-docs/inception/plans/issue-103-story-generation-plan.md (journey-based, small/vertical, checklist AC, Owner+Visitor personas, explicit cutover stories, US-### with FR mapping) — Approve & Continue to generate stories, or Request Changes."
+**Context**: INCEPTION — User Stories Part 1 plan approval gate.
+
+---
+
+## Issues #103 / #104 — Story Plan Approved / Generation Started
+**Timestamp**: 2026-07-16T17:22:30Z
+**User Input**: "approve and continue"
+**AI Response**: Story generation plan approved. Executing Part 2: generating issue-103-personas.md and issue-103-stories.md (journey-based, small/vertical, checklist AC, FR mapping).
+**Context**: INCEPTION — User Stories Part 2 Generation.
+
+---
+
+## Issues #103 / #104 — User Stories Generated / Approval Prompt
+**Timestamp**: 2026-07-16T17:24:00Z
+**User Input**: "(pending)"
+**AI Response**: Generated 2 personas (Site Owner, Visitor) and 16 journey-based stories (US-001–US-016) covering publish, edit, browse, galleries, and cutover. FR/NFR coverage matrix included. Presenting User Stories for approval before Workflow Planning.
+**Approval Prompt**: "User Stories Complete. Review aidlc-docs/inception/user-stories/issue-103-stories.md and issue-103-personas.md. Request Changes or Approve & Continue to Workflow Planning."
+**Context**: INCEPTION — User Stories approval gate.
+
+---
+
+## Issues #103 / #104 — User Stories Approved
+**Timestamp**: 2026-07-16T17:41:00Z
+**User Input**: "approve and continue"
+**AI Response**: User Stories approved. Proceeding to Workflow Planning — determining stage inclusion/depth, units sequence, and execution plan visualization.
+**Context**: INCEPTION — Workflow Planning.
+
+---
+
+## Issues #103 / #104 — Workflow Planning Approval Prompt
+**Timestamp**: 2026-07-16T17:42:00Z
+**User Input**: "(pending)"
+**AI Response**: Created issue-103-execution-plan.md. Risk High. Execute Application Design + Units Generation; full per-unit construction design path; ~7 tentative units. Extensions N/A. Presenting plan for approval.
+**Approval Prompt**: "Workflow Planning Complete. Review aidlc-docs/inception/plans/issue-103-execution-plan.md. Request Changes, Add Skipped Stages, or Approve & Continue to Application Design."
+**Context**: INCEPTION — Workflow Planning approval gate.
+
+---
+
+## Issues #103 / #104 — Workflow Plan Approved
+**Timestamp**: 2026-07-16T17:42:30Z
+**User Input**: "approve and proceed"
+**AI Response**: Workflow plan approved. Proceeding to Application Design (comprehensive) — components, services, methods, dependencies for photo DB migration.
+**Context**: INCEPTION — Application Design.
+
+---
+
+## Issues #103 / #104 — Application Design Plan Answers Received
+**Timestamp**: 2026-07-16T17:48:00Z
+**User Input**: "ok please see my answers and questions"
+**AI Response**: Reading issue-103-application-design-plan.md answers; validating ambiguities and responding to any user questions before plan approval / generation.
+**Context**: INCEPTION — Application Design; validating answers.
+
+---
+
+## Issues #103 / #104 — Application Design Clarifications Needed
+**Timestamp**: 2026-07-16T17:49:00Z
+**User Input**: "(answers: Q1=A, Q2=A, Q3=B, Q4=need more info, Q5=A+C, Q6=B with cost ask, Q7=C, Q8=A)"
+**AI Response**: Clarifications required for Q4 (frontend pattern explanation), Q5 (A+C decision rules), Q6 (AWS Location cost context + confirm). Created issue-103-application-design-clarifications.md. Stopping at clarification gate.
+**Context**: INCEPTION — Application Design; awaiting clarifications.
+
+---
+
+## Issues #103 / #104 — Application Design Clarifications Locked / Plan Approval Prompt
+**Timestamp**: 2026-07-16T17:50:30Z
+**User Input**: "Q4 - B sounds like the way to go\nQ5 - hub primary with detail shortcut\nQ6 - confirm stay with location"
+**AI Response**: Locked Q4=B (photos-api helpers), Q5=hub primary + detail Edit shortcut, Q6=AWS Location. Presenting Application Design plan for explicit approval before generating design artifacts.
+**Approval Prompt**: "Approve Application Design plan at issue-103-application-design-plan.md (with clarifications) to generate components/services/dependency docs, or Request Changes."
+**Context**: INCEPTION — Application Design plan approval gate.
+
+---
+
+## Issues #103 / #104 — Application Design Plan Approved / Generation Started
+**Timestamp**: 2026-07-16T17:52:00Z
+**User Input**: "approve and continue"
+**AI Response**: Application Design plan approved. Generating components, methods, services, dependency, and consolidated application-design docs.
+**Context**: INCEPTION — Application Design generation.
+
+---
+
+## Issues #103 / #104 — Application Design Generated / Approval Prompt
+**Timestamp**: 2026-07-16T17:54:00Z
+**User Input**: "(pending)"
+**AI Response**: Generated application-design artifacts (components, methods, services, dependencies, consolidated). Presenting for approval before Units Generation.
+**Approval Prompt**: "Application Design Complete. Review aidlc-docs/inception/application-design/. Request Changes or Approve & Continue to Units Generation."
+**Context**: INCEPTION — Application Design approval gate.
+
+---
+
+## Issues #103 / #104 — Application Design Approved
+**Timestamp**: 2026-07-16T17:54:30Z
+**User Input**: "approve and continue"
+**AI Response**: Application Design approved. Proceeding to Units Generation — planning unit decomposition along critical path from execution plan + application design.
+**Context**: INCEPTION — Units Generation.
+
+---
+
+## Issues #103 / #104 — Units Plan Answers Received
+**Timestamp**: 2026-07-16T17:56:00Z
+**User Input**: "done"
+**AI Response**: Reading issue-103-unit-of-work-plan.md answers; validating before plan approval / generation.
+**Context**: INCEPTION — Units Generation; validating answers.
+
+---
+
+## Issues #103 / #104 — Units Plan Approval Prompt
+**Timestamp**: 2026-07-16T17:56:30Z
+**User Input**: "(pending)"
+**AI Response**: Units plan answers validated (all A): 7 units, strict sequential, no dual-write, single owner, per-unit demoable, journey-aligned. Presenting plan for approval before generating unit artifacts.
+**Approval Prompt**: "Unit of work plan complete. Review aidlc-docs/inception/plans/issue-103-unit-of-work-plan.md. Ready to proceed to generation? Approve & Continue or Request Changes."
+**Context**: INCEPTION — Units Generation plan approval gate.
+
+---
+
+## Issues #103 / #104 — Units Plan Approved / Generation Started
+**Timestamp**: 2026-07-16T17:59:00Z
+**User Input**: "approved"
+**AI Response**: Unit of work plan approved. Generating unit-of-work.md, unit-of-work-dependency.md, unit-of-work-story-map.md.
+**Context**: INCEPTION — Units Generation Part 2.
+
+---
+
+## Issues #103 / #104 — Units Generated / Approval Prompt
+**Timestamp**: 2026-07-16T18:00:00Z
+**User Input**: "(pending)"
+**AI Response**: Generated 7 units (U1–U7), dependency matrix (strict sequential), story map (US-001–016 all assigned). Presenting Units Generation for approval before CONSTRUCTION (start U1).
+**Approval Prompt**: "Units Generation Complete. Review aidlc-docs/inception/application-design/unit-of-work*.md. Request Changes or Approve & Continue to CONSTRUCTION PHASE (U1 Functional Design)."
+**Context**: INCEPTION — Units Generation approval gate.
+
+---
+
+## Issues #103 / #104 — Units Approved + Commit Requested
+**Timestamp**: 2026-07-16T18:00:30Z
+**User Input**: "lets do a commit and then approved to move to construction"
+**AI Response**: Units Generation approved. Committing AI-DLC inception artifacts on branch cursor/photo-metadata-dynamodb-be02. Proceeding to CONSTRUCTION — Unit U1 Functional Design.
+**Context**: CONSTRUCTION — U1 Functional Design starting.
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -446,3 +446,119 @@
 **Context**: CONSTRUCTION — U1 Functional Design starting.
 
 ---
+
+## Issues #103 / #104 — U1 Functional Design Answers Received
+**Timestamp**: 2026-07-16T18:04:00Z
+**User Input**: "done"
+**AI Response**: Reading u1-photo-data-plane-functional-design-plan.md answers; validating before generating functional design artifacts.
+**Context**: CONSTRUCTION — U1 Functional Design; validating answers.
+
+---
+
+## Issues #103 / #104 — U1 FD Clarification (Q8 Auth)
+**Timestamp**: 2026-07-16T18:04:30Z
+**User Input**: "(answers Q1=A Q2=A Q3=B Q4=A Q5=A Q6=A Q7=A Q8=A — Q8 ambiguous)"
+**AI Response**: Clarification needed on process IAM vs HMAC. Created u1-photo-data-plane-functional-design-clarification.md.
+**Context**: CONSTRUCTION — U1 Functional Design; awaiting Q8 clarification.
+
+---
+
+## Issues #103 / #104 — U1 FD Clarification Locked / Generating
+**Timestamp**: 2026-07-16T18:05:30Z
+**User Input**: "lets do the recomended approach here"
+**AI Response**: Locked Q8=A (process IAM; browser HMAC). Generating U1 functional design artifacts.
+**Context**: CONSTRUCTION — U1 Functional Design generation.
+
+---
+
+## Issues #103 / #104 — U1 Functional Design Complete / Approval Prompt
+**Timestamp**: 2026-07-16T18:06:00Z
+**User Input**: "(pending)"
+**AI Response**: Generated U1 business-logic-model, business-rules, domain-entities. Auth: process IAM + browser HMAC. Presenting standardized 2-option completion for Functional Design.
+**Approval Prompt**: "Functional Design Complete - U1. Review aidlc-docs/construction/u1-photo-data-plane/functional-design/. Request Changes or Continue to Next Stage (NFR Requirements)."
+**Context**: CONSTRUCTION — U1 Functional Design approval gate.
+
+---
+
+## Issues #103 / #104 — U1 Functional Design Approved
+**Timestamp**: 2026-07-16T18:07:00Z
+**User Input**: "approved"
+**AI Response**: U1 Functional Design approved. Proceeding to U1 NFR Requirements.
+**Context**: CONSTRUCTION — U1 NFR Requirements.
+
+---
+
+## Issues #103 / #104 — U1 NFR Requirements Answers Received
+**Timestamp**: 2026-07-16T18:10:00Z
+**User Input**: "done"
+**AI Response**: Reading U1 NFR requirements plan answers; validating then generating nfr-requirements.md and tech-stack-decisions.md if clear.
+**Context**: CONSTRUCTION — U1 NFR Requirements; validating answers.
+
+---
+
+## Issues #103 / #104 — U1 NFR Requirements Complete / Approval Prompt
+**Timestamp**: 2026-07-16T18:11:00Z
+**User Input**: "(pending)"
+**AI Response**: All NFR answers A. Generated nfr-requirements.md and tech-stack-decisions.md. Presenting for approval before NFR Design.
+**Approval Prompt**: "NFR Requirements Complete - U1. Review aidlc-docs/construction/u1-photo-data-plane/nfr-requirements/. Request Changes or Continue to Next Stage (NFR Design)."
+**Context**: CONSTRUCTION — U1 NFR Requirements approval gate.
+
+---
+
+## Issues #103 / #104 — U1 NFR Requirements Approved
+**Timestamp**: 2026-07-16T18:11:30Z
+**User Input**: "approved"
+**AI Response**: U1 NFR Requirements approved. Proceeding to U1 NFR Design.
+**Context**: CONSTRUCTION — U1 NFR Design.
+
+---
+
+## Issues #103 / #104 — U1 NFR Design Answers Received
+**Timestamp**: 2026-07-16T18:55:00Z
+**User Input**: "done"
+**AI Response**: Reading U1 NFR design plan answers; validating then generating nfr-design artifacts if clear.
+**Context**: CONSTRUCTION — U1 NFR Design; validating answers.
+
+---
+
+## Issues #103 / #104 — U1 NFR Design Complete / Approval Prompt
+**Timestamp**: 2026-07-16T18:58:30Z
+**User Input**: "(pending)"
+**AI Response**: Generated nfr-design-patterns.md and logical-components.md (DLQ, best-effort enqueue, on-demand, GSI, minimal components). Presenting for approval before Infrastructure Design.
+**Approval Prompt**: "NFR Design Complete - U1. Review aidlc-docs/construction/u1-photo-data-plane/nfr-design/. Request Changes or Continue to Next Stage (Infrastructure Design)."
+**Context**: CONSTRUCTION — U1 NFR Design approval gate.
+
+---
+
+## Issues #103 / #104 — U1 NFR Design Approved
+**Timestamp**: 2026-07-16T19:02:00Z
+**User Input**: "approved"
+**AI Response**: U1 NFR Design approved. Proceeding to U1 Infrastructure Design.
+**Context**: CONSTRUCTION — U1 Infrastructure Design.
+
+---
+
+## Issues #103 / #104 — U1 Infrastructure Design Answers Received
+**Timestamp**: 2026-07-16T19:05:30Z
+**User Input**: "done"
+**AI Response**: Answers locked (table micahwalter-photos, GSI PHOTO/publishedAt#id, EventBridge enrichment stub, process SQS DLQ, same zip, PITR on, strip GitHub commit, no shared doc). Generating infrastructure design artifacts.
+**Context**: CONSTRUCTION — U1 Infrastructure Design generation.
+
+---
+
+## Issues #103 / #104 — U1 Infrastructure Design Complete / Approval Prompt
+**Timestamp**: 2026-07-16T19:06:00Z
+**User Input**: "(pending)"
+**AI Response**: Generated infrastructure-design.md and deployment-architecture.md. Presenting for approval before Code Generation.
+**Approval Prompt**: "Infrastructure Design Complete - U1. Review aidlc-docs/construction/u1-photo-data-plane/infrastructure-design/. Request Changes or Continue to Next Stage (Code Generation)."
+**Context**: CONSTRUCTION — U1 Infrastructure Design approval gate.
+
+---
+
+## Issues #103 / #104 — U1 Infrastructure Design Approved + Commit
+**Timestamp**: 2026-07-16T19:07:00Z
+**User Input**: "approved, but lets commit changes here"
+**AI Response**: U1 Infrastructure Design approved. Committing construction artifacts. Starting Code Generation Part 1 (plan) for U1.
+**Context**: CONSTRUCTION — U1 Code Generation planning.
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -562,3 +562,12 @@
 **Context**: CONSTRUCTION — U1 Code Generation planning.
 
 ---
+
+## Issues #103 / #104 — U1 Code Generation Plan Approval Prompt
+**Timestamp**: 2026-07-16T19:08:00Z
+**User Input**: "(pending)"
+**AI Response**: Committed 6f85a6a with U1 design artifacts + code-generation plan. Presenting plan for approval before Part 2 implementation.
+**Approval Prompt**: "Review aidlc-docs/construction/plans/u1-photo-data-plane-code-generation-plan.md (9 steps: DB layer, DTO/auth, HTTP handlers, process changes, init caption, CFN/IAM, package docs, summary, verify). Approve to implement, or Request Changes."
+**Context**: CONSTRUCTION — U1 Code Generation plan approval gate.
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -579,3 +579,12 @@
 **Context**: CONSTRUCTION — U1 Code Generation Part 2.
 
 ---
+
+## Issues #103 / #104 — U1 Code Generation Implementation Complete
+**Timestamp**: 2026-07-16T19:20:00Z
+**User Input**: "(pending Continue)"
+**AI Response**: Implemented U1: DynamoDB photos API, process→DB+EventBridge, strip GitHub commit, CFN table/bus/DLQ/routes. Local require() OK; CFN validate deferred (no AWS creds). Presenting Code Generation completion for Continue to U2 or Request Changes.
+**Approval Prompt**: "Code Generation Complete - U1. Review implementation + code-summary. Request Changes or Continue to Next Stage (U2 Functional Design)."
+**Context**: CONSTRUCTION — U1 Code Generation approval gate.
+
+---

--- a/aidlc-docs/construction/plans/u1-photo-data-plane-code-generation-plan.md
+++ b/aidlc-docs/construction/plans/u1-photo-data-plane-code-generation-plan.md
@@ -22,54 +22,54 @@ This plan is the **single source of truth** for U1 Code Generation. Execute step
 ## Generation steps
 
 ### Step 1 — Repository / domain layer
-- [ ] Add Photo record helpers (defaults for title/caption, GSI keys `gsi1pk`/`gsi1sk`, timestamps)
-- [ ] Add DynamoDB client module: `putPhoto`, `getPhoto`, `updatePhoto`, `listPhotos` (cursor), `getFeaturedPhoto`
-- [ ] Files under `infra/photo-upload-lambdas/src/lib/` (e.g. `photos-db.js`, `photo-defaults.js`)
+- [x] Add Photo record helpers (defaults for title/caption, GSI keys `gsi1pk`/`gsi1sk`, timestamps)
+- [x] Add DynamoDB client module: `putPhoto`, `getPhoto`, `updatePhoto`, `listPhotos` (cursor), `getFeaturedPhoto`
+- [x] Files under `infra/photo-upload-lambdas/src/lib/` (e.g. `photos-db.js`, `photo-defaults.js`)
 
 ### Step 2 — Public DTO + auth reuse
-- [ ] Add `PublicDtoProjector` (strip precise GPS)
-- [ ] Reuse existing token verify for PATCH
-- [ ] Files: e.g. `src/lib/photo-dto.js`; wire existing `token.js`
+- [x] Add `PublicDtoProjector` (strip precise GPS)
+- [x] Reuse existing token verify for PATCH
+- [x] Files: e.g. `src/lib/photo-dto.js`; wire existing `token.js`
 
 ### Step 3 — HTTP read/patch handlers
-- [ ] Implement GET `/photos`, GET `/photos/featured`, GET `/photos/{id}`, PATCH `/photos/{id}`
-- [ ] Cursor pagination: default limit 12, max 50
-- [ ] Draft filtering on public reads
-- [ ] Files: e.g. `src/list.js`, `src/get.js`, `src/featured.js`, `src/patch.js` — or single `src/photos-api.js` router if cleaner for one zip
-- [ ] Export handlers for Lambda entrypoints in package.json / CFN
+- [x] Implement GET `/photos`, GET `/photos/featured`, GET `/photos/{id}`, PATCH `/photos/{id}`
+- [x] Cursor pagination: default limit 12, max 50
+- [x] Draft filtering on public reads
+- [x] Files: e.g. `src/list.js`, `src/get.js`, `src/featured.js`, `src/patch.js` — or single `src/photos-api.js` router if cleaner for one zip
+- [x] Export handlers for Lambda entrypoints in package.json / CFN
 
 ### Step 4 — Process pipeline changes
-- [ ] After optimize + ticket id: build Photo + `putPhoto` (`enrichmentStatus=pending`)
-- [ ] Best-effort EventBridge `PutEvents` (`PhotoPendingEnrichment` / agreed source+detail-type)
-- [ ] **Remove** GitHub commit path (`lib/github.js` usage from process; stop requiring githubToken in process)
-- [ ] Fail closed: no DDB write if optimize or ticket fails
-- [ ] Accept `caption` from S3 object metadata (alongside title/featured)
-- [ ] File: `src/process.js` (+ init metadata if needed in `src/init.js`)
+- [x] After optimize + ticket id: build Photo + `putPhoto` (`enrichmentStatus=pending`)
+- [x] Best-effort EventBridge `PutEvents` (`PhotoPendingEnrichment` / agreed source+detail-type)
+- [x] **Remove** GitHub commit path (`lib/github.js` usage from process; stop requiring githubToken in process)
+- [x] Fail closed: no DDB write if optimize or ticket fails
+- [x] Accept `caption` from S3 object metadata (alongside title/featured)
+- [x] File: `src/process.js` (+ init metadata if needed in `src/init.js`)
 
 ### Step 5 — Init metadata for caption
-- [ ] Extend `upload-url` / init to accept `caption` and pass as S3 metadata (signed headers pattern preserved)
-- [ ] File: `src/init.js`
+- [x] Extend `upload-url` / init to accept `caption` and pass as S3 metadata (signed headers pattern preserved)
+- [x] File: `src/init.js`
 
 ### Step 6 — CloudFormation / IAM
-- [ ] Add DynamoDB table `micahwalter-photos` + GSI1 + PITR
-- [ ] Add EventBridge bus (or document default-bus source) for enrichment events
-- [ ] Add SQS process DLQ + Lambda OnFailure destination for ProcessFn
-- [ ] Add API routes for GET/PATCH; wire new handler env (table name, bus name)
-- [ ] IAM: DynamoDB + `events:PutEvents`; remove process GitHub permissions if present
-- [ ] File: `infra/photo-upload.yml`
+- [x] Add DynamoDB table `micahwalter-photos` + GSI1 + PITR
+- [x] Add EventBridge bus (or document default-bus source) for enrichment events
+- [x] Add SQS process DLQ + Lambda OnFailure destination for ProcessFn
+- [x] Add API routes for GET/PATCH; wire new handler env (table name, bus name)
+- [x] IAM: DynamoDB + `events:PutEvents`; remove process GitHub permissions if present
+- [x] File: `infra/photo-upload.yml`
 
 ### Step 7 — Package / build wiring
-- [ ] Ensure Makefile/zip includes new modules; handler names match CFN
-- [ ] Update `infra/photo-upload-lambdas/README.md` for new behavior (no git commit; DB + events)
+- [x] Ensure Makefile/zip includes new modules; handler names match CFN
+- [x] Update `infra/photo-upload-lambdas/README.md` for new behavior (no git commit; DB + events)
 
 ### Step 8 — Docs in aidlc construction summary (markdown only under aidlc-docs)
-- [ ] Write `aidlc-docs/construction/u1-photo-data-plane/code/code-summary.md` (what changed, how to deploy/smoke)
-- [ ] Note: no automated test runner in repo — document manual/API smoke checklist instead of inventing a test framework
+- [x] Write `aidlc-docs/construction/u1-photo-data-plane/code/code-summary.md` (what changed, how to deploy/smoke)
+- [x] Note: no automated test runner in repo — document manual/API smoke checklist instead of inventing a test framework
 
 ### Step 9 — Local verification (as far as environment allows)
-- [ ] Syntax-check / package install in `photo-upload-lambdas` if needed
-- [ ] Validate CFN template with `aws cloudformation validate-template` if credentials available; otherwise note deferred
-- [ ] Do **not** require full AWS deploy in this agent unless user asks
+- [x] Syntax-check / package install in `photo-upload-lambdas` if needed
+- [x] Validate CFN template with `aws cloudformation validate-template` if credentials available; otherwise note deferred
+- [x] Do **not** require full AWS deploy in this agent unless user asks
 
 ---
 

--- a/aidlc-docs/construction/plans/u1-photo-data-plane-code-generation-plan.md
+++ b/aidlc-docs/construction/plans/u1-photo-data-plane-code-generation-plan.md
@@ -1,0 +1,88 @@
+# U1 — Photo data plane — Code Generation Plan
+
+**Stories**: US-002  
+**Design inputs**: `aidlc-docs/construction/u1-photo-data-plane/{functional-design,nfr-requirements,nfr-design,infrastructure-design}/`  
+**Code location**: workspace root — primarily `infra/photo-upload-lambdas/`, `infra/photo-upload.yml` (NOT aidlc-docs/)  
+**Approach**: Brownfield — extend existing photo-upload package; strip GitHub commit from process  
+
+This plan is the **single source of truth** for U1 Code Generation. Execute steps in order; mark `[x]` when complete.
+
+---
+
+## Unit context
+
+| Item | Detail |
+|------|--------|
+| Deliverable | DynamoDB photos + public GET + HMAC PATCH + process persists to DB + EventBridge enrich event + process DLQ; no markdown commit |
+| Depends on | Existing tickets API, uploads/images buckets, photo-upload auth |
+| Enables | U2 enrichment consumer; U3/U4 clients |
+
+---
+
+## Generation steps
+
+### Step 1 — Repository / domain layer
+- [ ] Add Photo record helpers (defaults for title/caption, GSI keys `gsi1pk`/`gsi1sk`, timestamps)
+- [ ] Add DynamoDB client module: `putPhoto`, `getPhoto`, `updatePhoto`, `listPhotos` (cursor), `getFeaturedPhoto`
+- [ ] Files under `infra/photo-upload-lambdas/src/lib/` (e.g. `photos-db.js`, `photo-defaults.js`)
+
+### Step 2 — Public DTO + auth reuse
+- [ ] Add `PublicDtoProjector` (strip precise GPS)
+- [ ] Reuse existing token verify for PATCH
+- [ ] Files: e.g. `src/lib/photo-dto.js`; wire existing `token.js`
+
+### Step 3 — HTTP read/patch handlers
+- [ ] Implement GET `/photos`, GET `/photos/featured`, GET `/photos/{id}`, PATCH `/photos/{id}`
+- [ ] Cursor pagination: default limit 12, max 50
+- [ ] Draft filtering on public reads
+- [ ] Files: e.g. `src/list.js`, `src/get.js`, `src/featured.js`, `src/patch.js` — or single `src/photos-api.js` router if cleaner for one zip
+- [ ] Export handlers for Lambda entrypoints in package.json / CFN
+
+### Step 4 — Process pipeline changes
+- [ ] After optimize + ticket id: build Photo + `putPhoto` (`enrichmentStatus=pending`)
+- [ ] Best-effort EventBridge `PutEvents` (`PhotoPendingEnrichment` / agreed source+detail-type)
+- [ ] **Remove** GitHub commit path (`lib/github.js` usage from process; stop requiring githubToken in process)
+- [ ] Fail closed: no DDB write if optimize or ticket fails
+- [ ] Accept `caption` from S3 object metadata (alongside title/featured)
+- [ ] File: `src/process.js` (+ init metadata if needed in `src/init.js`)
+
+### Step 5 — Init metadata for caption
+- [ ] Extend `upload-url` / init to accept `caption` and pass as S3 metadata (signed headers pattern preserved)
+- [ ] File: `src/init.js`
+
+### Step 6 — CloudFormation / IAM
+- [ ] Add DynamoDB table `micahwalter-photos` + GSI1 + PITR
+- [ ] Add EventBridge bus (or document default-bus source) for enrichment events
+- [ ] Add SQS process DLQ + Lambda OnFailure destination for ProcessFn
+- [ ] Add API routes for GET/PATCH; wire new handler env (table name, bus name)
+- [ ] IAM: DynamoDB + `events:PutEvents`; remove process GitHub permissions if present
+- [ ] File: `infra/photo-upload.yml`
+
+### Step 7 — Package / build wiring
+- [ ] Ensure Makefile/zip includes new modules; handler names match CFN
+- [ ] Update `infra/photo-upload-lambdas/README.md` for new behavior (no git commit; DB + events)
+
+### Step 8 — Docs in aidlc construction summary (markdown only under aidlc-docs)
+- [ ] Write `aidlc-docs/construction/u1-photo-data-plane/code/code-summary.md` (what changed, how to deploy/smoke)
+- [ ] Note: no automated test runner in repo — document manual/API smoke checklist instead of inventing a test framework
+
+### Step 9 — Local verification (as far as environment allows)
+- [ ] Syntax-check / package install in `photo-upload-lambdas` if needed
+- [ ] Validate CFN template with `aws cloudformation validate-template` if credentials available; otherwise note deferred
+- [ ] Do **not** require full AWS deploy in this agent unless user asks
+
+---
+
+## Out of scope for this plan (later units)
+
+- Enrichment consumer (U2)
+- Next.js UI (U3–U5)
+- Galleries (U6)
+- Migration / redirects / feeds (U7)
+- Dual-write / markdown restore
+
+---
+
+## Approval
+
+Approve this plan to begin Part 2 execution (implementation).

--- a/aidlc-docs/construction/plans/u1-photo-data-plane-functional-design-clarification.md
+++ b/aidlc-docs/construction/plans/u1-photo-data-plane-functional-design-clarification.md
@@ -1,0 +1,36 @@
+# U1 Functional Design — Clarification
+
+## Ambiguity — Q8 Auth for writes
+
+You chose **A**. Option A’s wording mixed “HMAC token” and “IAM” for the process path.
+
+In practice for this architecture:
+
+- **Process Lambda** is triggered by S3 and should call DynamoDB with its **IAM role** (no browser token).
+- **Browser PATCH** (and future admin UI) should use the existing **passcode → HMAC token** (same as `/upload`).
+
+### Clarification Question 1
+
+Confirm write auth for U1:
+
+A) **Process = IAM only; browser PATCH = HMAC token** (recommended; matches how upload already works)
+
+B) **Every write including process must present HMAC** (unusual for S3-triggered Lambda — not recommended)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+**Already locked from your answers**
+
+| Q | Choice |
+|---|--------|
+| 1 | id PK + publishedAt + createdAt/updatedAt |
+| 2 | pending enrichment, already publicly listable |
+| 3 | title from filename; caption “Photo taken with {camera}” or empty |
+| 4 | publishedAt desc, id desc; cursor pagination |
+| 5 | newest featured, else newest overall |
+| 6 | draft supported; public omits drafts |
+| 7 | no DynamoDB write if optimize/ticket fails |

--- a/aidlc-docs/construction/plans/u1-photo-data-plane-functional-design-plan.md
+++ b/aidlc-docs/construction/plans/u1-photo-data-plane-functional-design-plan.md
@@ -18,23 +18,27 @@ B) **id as PK** + `publishedAt` only (no separate created/updated)
 
 X) Other (please describe after [Answer]: tag below)
 
-[Answer]: 
+[Answer]: A
 
 ---
 
+
+
 ### Question 2 — Initial record status after process (before enrichment)
 
-A) **`enrichmentStatus: pending`** — photo is already **publicly listable/gettable** (may lack AI tags/geo until U2)
+A) `enrichmentStatus: pending` — photo is already **publicly listable/gettable** (may lack AI tags/geo until U2)
 
-B) **`enrichmentStatus: pending` + `visibility: private`** until enrichment completes (or timeout) — then public
+B) `enrichmentStatus: pending` **+** `visibility: private` until enrichment completes (or timeout) — then public
 
 C) **Always public**; enrichmentStatus informational only
 
 X) Other (please describe after [Answer]: tag below)
 
-[Answer]: 
+[Answer]: A
 
 ---
+
+
 
 ### Question 3 — Caption / title defaults when upload omits them
 
@@ -46,57 +50,67 @@ C) **Require title** at init (reject upload-url without title); caption optional
 
 X) Other (please describe after [Answer]: tag below)
 
-[Answer]: 
+[Answer]: B
 
 ---
+
+
 
 ### Question 4 — Public list sort & pagination
 
-A) **Sort `publishedAt` desc, then `id` desc**; cursor pagination (`limit` + opaque cursor)
+A) **Sort** `publishedAt` **desc, then** `id` **desc**; cursor pagination (`limit` + opaque cursor)
 
-B) **Sort `publishedAt` desc**; offset/limit page numbers
+B) **Sort** `publishedAt` **desc**; offset/limit page numbers
 
 X) Other (please describe after [Answer]: tag below)
 
-[Answer]: 
+[Answer]: A
 
 ---
 
+
+
 ### Question 5 — Featured photo rule (API)
 
-A) **Newest photo with `featured=true`**; if none, newest photo overall (match today’s `getFeaturedPhoto`)
+A) **Newest photo with** `featured=true`; if none, newest photo overall (match today’s `getFeaturedPhoto`)
 
 B) **Newest featured only**; if none, return null (homepage hides hero)
 
 X) Other (please describe after [Answer]: tag below)
 
-[Answer]: 
+[Answer]: A
 
 ---
 
+
+
 ### Question 6 — Draft handling in U1
 
-A) **Support `draft` boolean**; public list/get omit drafts; auth get can include drafts
+A) **Support** `draft` **boolean**; public list/get omit drafts; auth get can include drafts
 
 B) **No drafts in U1** — all processed uploads are published (`draft=false` always)
 
 X) Other (please describe after [Answer]: tag below)
 
-[Answer]: 
+[Answer]: A
 
 ---
+
+
 
 ### Question 7 — Process failure / partial write rules
 
 A) **If optimize or ticket id fails → no DynamoDB write**; S3 original may remain (lifecycle expires). Log error.
 
-B) **Write a `failed` record** with error message when possible after id allocation, for admin visibility
+B) **Write a** `failed` **record** with error message when possible after id allocation, for admin visibility
 
 X) Other (please describe after [Answer]: tag below)
 
-[Answer]: 
+[Answer]: A
 
 ---
+
+
 
 ### Question 8 — Auth for write APIs in U1
 
@@ -106,16 +120,31 @@ B) **Process uses IAM only** (no token); browser PATCH uses HMAC token
 
 X) Other (please describe after [Answer]: tag below)
 
-[Answer]: 
+[Answer]: A
 
 ---
 
+
+
 ## Generation checklist (after answers + approval)
 
-- [ ] `business-logic-model.md`
-- [ ] `business-rules.md`
-- [ ] `domain-entities.md`
-- [ ] Update state/audit
+- [x] `business-logic-model.md`
+- [x] `business-rules.md`
+- [x] `domain-entities.md`
+- [x] Update state/audit
+
+## Decisions locked
+
+| Q | Decision |
+|---|----------|
+| 1 | id PK + publishedAt + createdAt/updatedAt |
+| 2 | pending enrichment, publicly listable |
+| 3 | title from filename; caption from camera or empty |
+| 4 | publishedAt/id desc; cursor pagination |
+| 5 | newest featured else newest |
+| 6 | draft supported; public omits drafts |
+| 7 | no DDB write if optimize/ticket fails |
+| 8 | Process IAM; browser PATCH HMAC |
 
 ---
 

--- a/aidlc-docs/construction/plans/u1-photo-data-plane-functional-design-plan.md
+++ b/aidlc-docs/construction/plans/u1-photo-data-plane-functional-design-plan.md
@@ -1,0 +1,122 @@
+# U1 — Photo data plane — Functional Design Plan
+
+**Unit**: U1 Photo data plane  
+**Stories**: US-002  
+**Components**: PhotoRepository, PhotoCommandService, PhotoQueryService, UploadProcessPipeline (persist), Auth  
+
+Please answer every `[Answer]:` below. After validation and plan approval, artifacts will be generated under `aidlc-docs/construction/u1-photo-data-plane/functional-design/`.
+
+---
+
+## Questions
+
+### Question 1 — Photo record identity & timestamps
+
+A) **id (number/string from tickets) as partition key**; `publishedAt` ISO date; `createdAt`/`updatedAt` ISO timestamps on every write
+
+B) **id as PK** + `publishedAt` only (no separate created/updated)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+---
+
+### Question 2 — Initial record status after process (before enrichment)
+
+A) **`enrichmentStatus: pending`** — photo is already **publicly listable/gettable** (may lack AI tags/geo until U2)
+
+B) **`enrichmentStatus: pending` + `visibility: private`** until enrichment completes (or timeout) — then public
+
+C) **Always public**; enrichmentStatus informational only
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+---
+
+### Question 3 — Caption / title defaults when upload omits them
+
+A) **Title** defaults to sanitized filename; **caption** defaults to empty string (UI may show nothing)
+
+B) **Title** from filename; **caption** defaults to legacy-style “Photo taken with {camera}” when EXIF camera exists, else empty
+
+C) **Require title** at init (reject upload-url without title); caption optional empty
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+---
+
+### Question 4 — Public list sort & pagination
+
+A) **Sort `publishedAt` desc, then `id` desc**; cursor pagination (`limit` + opaque cursor)
+
+B) **Sort `publishedAt` desc**; offset/limit page numbers
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+---
+
+### Question 5 — Featured photo rule (API)
+
+A) **Newest photo with `featured=true`**; if none, newest photo overall (match today’s `getFeaturedPhoto`)
+
+B) **Newest featured only**; if none, return null (homepage hides hero)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+---
+
+### Question 6 — Draft handling in U1
+
+A) **Support `draft` boolean**; public list/get omit drafts; auth get can include drafts
+
+B) **No drafts in U1** — all processed uploads are published (`draft=false` always)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+---
+
+### Question 7 — Process failure / partial write rules
+
+A) **If optimize or ticket id fails → no DynamoDB write**; S3 original may remain (lifecycle expires). Log error.
+
+B) **Write a `failed` record** with error message when possible after id allocation, for admin visibility
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+---
+
+### Question 8 — Auth for write APIs in U1
+
+A) **Reuse existing photo-upload HMAC token** (same as `/upload`) for create-from-process (IAM) and owner PATCH
+
+B) **Process uses IAM only** (no token); browser PATCH uses HMAC token
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+---
+
+## Generation checklist (after answers + approval)
+
+- [ ] `business-logic-model.md`
+- [ ] `business-rules.md`
+- [ ] `domain-entities.md`
+- [ ] Update state/audit
+
+---
+
+When done answering, reply in chat.

--- a/aidlc-docs/construction/plans/u1-photo-data-plane-infrastructure-design-plan.md
+++ b/aidlc-docs/construction/plans/u1-photo-data-plane-infrastructure-design-plan.md
@@ -1,0 +1,146 @@
+# U1 — Photo data plane — Infrastructure Design Plan
+
+**Map**: Logical components → AWS on existing `micahwalter-photo-upload` stack  
+**Region**: us-east-1 (U1)
+
+Please answer every `[Answer]:` below.
+
+---
+
+## Questions
+
+### Question 1 — DynamoDB table name
+
+A) `photos` (simple; stack-scoped account)
+
+B) `micahwalter-photos` (prefixed, matches other resource naming)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B
+
+---
+
+### Question 2 — GSI shape for newest-first list
+
+A) **GSI1**: `gsi1pk` = constant `"PHOTO"`, `gsi1sk` = `{publishedAt}#{id}` (query newest with `ScanIndexForward=false`)
+
+B) **GSI1**: `entityType` = `"photo"`, `publishedAt` as SK (id tie-break in filter/app if collisions)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 3 — Enrichment queue (publisher target in U1)
+
+A) **Create SQS queue now** — e.g. `photo-enrichment-queue` + DLQ; process sends message; U2 adds consumer
+
+B) **EventBridge custom bus/rule stub** — process PutEvents; U2 adds target
+
+C) **Create queue in U2 only** — U1 PutItem without send (contradicts best-effort enqueue — only if you change that)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B
+
+---
+
+
+
+### Question 4 — Process failure DLQ
+
+A) **SQS DLQ** attached as Lambda `OnFailure` / Destination for async invoke from S3
+
+B) **S3 event → SQS → Process** (queue between S3 and worker) with redrive DLQ — larger change
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 5 — New HTTP Lambdas vs monolithic zip
+
+A) **Add routes in same zip** — new handlers in `photo-upload-lambdas` package (get/list/featured/patch) + CFN routes; keep one deployable artifact
+
+B) **Separate Lambda functions** per route group (read vs write) still in same CFN stack
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 6 — DynamoDB backups / PITR in U1
+
+A) **PITR enabled** on photos table
+
+B) **PITR off in U1** — enable later
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 7 — Remove GitHub commit from process IAM/secrets
+
+A) **Strip GitHub commit in U1** — remove commit code path; drop `githubToken` usage from process (secret field may remain unused until cleaned)
+
+B) **Feature-flag keep code but disabled** — leave GitHub client dead-coded behind env `COMMIT_MARKDOWN=false`
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 8 — Shared infrastructure doc
+
+A) **No separate shared-infrastructure.md** — document stack extension only under U1 infra design
+
+B) **Create shared-infrastructure.md** noting api-domain, tickets, images bucket, artifacts bucket reuse
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+## Generation checklist
+
+- [x] `infrastructure-design.md`
+- [x] `deployment-architecture.md`
+- [x] `shared-infrastructure.md` if B on Q8 — **skipped** (Q8=A)
+- [x] Update state/audit
+
+## Decisions locked
+
+| Q | Choice |
+|---|--------|
+| 1 | B — table `micahwalter-photos` |
+| 2 | A — GSI1 `PHOTO` / `{publishedAt}#{id}` |
+| 3 | B — EventBridge enrichment stub |
+| 4 | A — SQS process OnFailure DLQ |
+| 5 | A — same Lambda zip + new routes |
+| 6 | A — PITR on |
+| 7 | A — strip GitHub commit from process |
+| 8 | A — no separate shared-infrastructure.md |
+
+---
+
+When done, reply in chat.

--- a/aidlc-docs/construction/plans/u1-photo-data-plane-nfr-design-plan.md
+++ b/aidlc-docs/construction/plans/u1-photo-data-plane-nfr-design-plan.md
@@ -1,0 +1,123 @@
+# U1 — Photo data plane — NFR Design Plan
+
+**Inputs**: `u1-photo-data-plane/nfr-requirements/` (approved)  
+**Goal**: Choose patterns and logical components (not AWS resource names yet — that is Infrastructure Design)
+
+Please answer every `[Answer]:` below.
+
+---
+
+## Questions
+
+### Question 1 — Resilience / retries (process path)
+
+A) **Fail fast, no retries in-process** — optimize/ticket failure → log + exit; rely on S3/Lambda redrive only if AWS retries the event; no DynamoDB row
+
+B) **Limited retries** — retry ticket allocation 2–3 times with backoff; still no DDB row if still failing
+
+C) **S3 retry + DLQ pattern in U1** — configure process failure destination for poison messages
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: C
+
+---
+
+
+
+### Question 2 — Enrichment enqueue resilience (U1 responsibility)
+
+A) **Best-effort enqueue** — if queue send fails after successful PutItem, log error; photo remains `pending` for U2/manual redrive later
+
+B) **Transactional outbox style** — don’t consider process success until enqueue succeeds (retry enqueue); else fail process after Put (accept possible orphan row + log)
+
+C) **Defer enqueue wiring** — U1 only PutItem; U2 adds queue + backfill pending rows
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 3 — Scalability pattern
+
+A) **Serverless on-demand only** — DynamoDB on-demand + Lambda concurrency defaults; no reserved concurrency
+
+B) **Cap process concurrency** — reserved concurrency on process Lambda to protect optimize/sharp memory
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 4 — Performance pattern for reads
+
+A) **Single-table query via GSI** — `publishedAt`+`id` access pattern; no in-memory cache component
+
+B) **GSI + tiny in-Lambda memory cache** — cache featured result for ~30–60s in process memory (optional)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 5 — Security patterns
+
+A) **Gateway + token verify middleware pattern** — shared `assertAuth(token)` on PATCH; DTO projector strips sensitive fields; least-privilege IAM roles per Lambda
+
+B) **A + request body size limits** on PATCH/init at API Gateway
+
+C) **A + B**
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 6 — Logical components to include in U1 NFR design
+
+A) **Minimal set** — PhotoStore (DynamoDB), PhotoHttpApi, ProcessWorker, TicketClient, ImageOptimizer, EnrichmentQueuePublisher (client only), AuthVerifier, PublicDtoProjector
+
+B) **Minimal + IdempotencyGuard** — also track processed S3 object keys to avoid double-create on Lambda retry
+
+C) **Minimal + IdempotencyGuard + CursorCodec** — explicit component for opaque list cursors
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+## Generation checklist
+
+- [x] `nfr-design-patterns.md`
+- [x] `logical-components.md`
+- [x] Update state/audit
+
+## Decisions locked
+
+| Q | Choice |
+|---|--------|
+| 1 | C — Process DLQ / failure destination |
+| 2 | A — Best-effort enrichment enqueue |
+| 3 | A — On-demand, no reserved concurrency |
+| 4 | A — GSI reads, no in-memory cache |
+| 5 | A — AuthVerifier + DTO projector + least privilege |
+| 6 | A — Minimal logical component set |
+
+---
+
+When done, reply in chat.

--- a/aidlc-docs/construction/plans/u1-photo-data-plane-nfr-requirements-plan.md
+++ b/aidlc-docs/construction/plans/u1-photo-data-plane-nfr-requirements-plan.md
@@ -1,0 +1,142 @@
+# U1 — Photo data plane — NFR Requirements Plan
+
+**Unit**: U1 Photo data plane  
+**Context**: Personal site API; DynamoDB photos; Node Lambdas on existing photo-upload stack  
+
+Please answer every `[Answer]:` below.
+
+---
+
+## Questions
+
+### Question 1 — Expected load / scalability
+
+A) **Personal / low traffic** — Design for tens of uploads/day and low thousands of reads/day; single-region primary sufficient for U1 (multi-region in U7)
+
+B) **Burst-friendly personal** — Same baseline traffic but size Lambdas/API for occasional spikes (e.g. homepage traffic after a post)
+
+C) **Provision for growth now** — Higher read capacity / caching assumptions beyond current personal traffic
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 2 — API latency targets (public GET)
+
+A) **Best effort** — No hard SLO; p95 under ~500ms when warm is a soft goal
+
+B) **Soft SLO** — p95 < 300ms for get/list when warm; document cold-start separately
+
+C) **Strict** — p95 < 200ms get; add CloudFront/API caching in U1
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 3 — Caching for public reads in U1
+
+A) **No CDN cache on API in U1** — Direct API Gateway → Lambda → DynamoDB; add caching in later unit if needed
+
+B) **Short Cache-Control on GET** — e.g. 30–60s public cache headers for list/get/featured
+
+C) **CloudFront in front of photo API GETs** — more infra in U1
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 4 — Availability for U1
+
+A) **Match current photo-upload stack** — us-east-1 primary; no new multi-region in U1 (U7 handles parity)
+
+B) **DynamoDB global tables from U1** — start multi-region data plane immediately
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 5 — Security baseline for U1 (practical NFRs)
+
+A) **Confirm defaults** — Public GET open; PATCH HMAC; process IAM; no precise GPS in public DTO; secrets in Secrets Manager only
+
+B) **Add rate limiting** — API Gateway throttle/burst limits on public GET and auth endpoints in U1
+
+C) **A + B**
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 6 — Observability
+
+A) **CloudWatch logs + basic metrics** — Lambda logs; API 4xx/5xx; DynamoDB errors (match existing stacks)
+
+B) **A + structured log fields** — photo id, enrichmentStatus, latency on each request
+
+C) **A + B + alarms** — e.g. 5xx rate / process failures SNS in U1
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 7 — Tech stack confirmation for U1
+
+A) **Confirm locked stack** — Node.js Lambdas, API Gateway HTTP API on existing photo-upload stack, DynamoDB, AWS SDK v3, existing HMAC auth lib patterns
+
+B) **Same as A but new DynamoDB table name/prefix preference** (describe under Other if needed — use X)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 8 — Pagination page size defaults
+
+A) **Default limit 12** (match current `/photos` page size), max 50
+
+B) **Default limit 24**, max 100
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+## Generation checklist (after answers)
+
+- [ ] `nfr-requirements.md`
+- [ ] `tech-stack-decisions.md`
+- [ ] Update state/audit
+
+---
+
+When done, reply in chat.

--- a/aidlc-docs/construction/u1-photo-data-plane/code/code-summary.md
+++ b/aidlc-docs/construction/u1-photo-data-plane/code/code-summary.md
@@ -1,0 +1,43 @@
+# U1 Code Summary — Photo data plane
+
+**Story**: US-002  
+**Branch**: `cursor/photo-metadata-dynamodb-be02`
+
+## What changed
+
+### Lambda package (`infra/photo-upload-lambdas/`)
+- Added `lib/photo-defaults.js`, `lib/photos-db.js`, `lib/photo-dto.js`
+- Added `photos-api.js` — GET list/featured/{id}, PATCH {id}
+- Rewrote `process.js` — DynamoDB put + EventBridge enrich event; **removed GitHub commit**
+- Extended `init.js` — `caption` S3 metadata
+- Dependencies: DynamoDB Document client, EventBridge client
+
+### CloudFormation (`infra/photo-upload.yml`)
+- Table `micahwalter-photos` + GSI1 + PITR
+- Event bus `photo-bus`
+- Process DLQ + `EventInvokeConfig` OnFailure
+- `PhotosApiFn` + routes; CORS GET/PATCH; IAM updates
+- Removed process env `GITHUB_*`
+
+## Deploy
+
+1. `cd infra/photo-upload-lambdas && make build`
+2. Upload zip + `aws cloudformation deploy` stack `micahwalter-photo-upload` (or merge to `main` for `photo-upload-deploy.yml`)
+3. Confirm secret has `passcode`, `hmac`, `ticketsPasscode`
+
+## Smoke checklist (after deploy)
+
+- [ ] `GET https://api.micahwalter.com/photos` → `{ items, cursor }`
+- [ ] `GET .../photos/featured` → 404 until first photo or 200
+- [ ] Upload via `/upload` (title only still OK) → row in DynamoDB, images on CDN, **no** new `content/posts` commit
+- [ ] `GET .../photos/{id}` returns caption/title
+- [ ] `PATCH .../photos/{id}` with valid token updates title
+- [ ] Failed process events appear on `photo-upload-process-dlq` after retries
+- [ ] EventBridge `photo-bus` receives `PhotoPendingEnrichment` (U2 will consume)
+
+## Known U1 limits
+
+- No enricher yet (tags/geo stay empty/pending)
+- No IdempotencyGuard — rare S3 redrive after successful put could allocate a second id
+- Frontend still filesystem-backed until U4
+- `aws cloudformation validate-template` deferred here (no AWS credentials in agent); validate on deploy

--- a/aidlc-docs/construction/u1-photo-data-plane/functional-design/business-logic-model.md
+++ b/aidlc-docs/construction/u1-photo-data-plane/functional-design/business-logic-model.md
@@ -1,0 +1,71 @@
+# U1 — Business Logic Model
+
+**Unit**: Photo data plane  
+**Story**: US-002  
+
+---
+
+## Purpose
+
+Persist photo metadata in DynamoDB when an upload is processed, expose public read and authenticated update APIs, and stop writing photo markdown to git.
+
+## Primary workflow — Process persist
+
+```text
+S3 ObjectCreated (uploads bucket)
+  -> load object + user metadata (title, caption, featured)
+  -> optimize images to images bucket
+  -> allocate ticket id
+  -> build Photo record (defaults applied)
+  -> PutItem DynamoDB
+  -> enqueue enrichment (U2; out of scope for U1 logic details)
+  -> DONE (no GitHub commit)
+```
+
+### Failure short-circuit
+If optimize **or** ticket allocation fails → **no DynamoDB write**; log error; S3 original may remain until lifecycle expiry.
+
+## Secondary workflow — Public read
+
+```text
+Client -> GET list | get by id | featured | (search stub/contract if included)
+  -> load from repository
+  -> filter draft=false for public
+  -> map to PublicPhotoDTO (no precise GPS in U1; fields may be null until U2)
+  -> return
+```
+
+## Tertiary workflow — Authenticated metadata update
+
+```text
+Client -> PATCH /photos/{id} + HMAC token
+  -> verify token
+  -> load photo
+  -> apply allowed patch fields
+  -> updatedAt = now
+  -> save
+  -> return record/DTO
+```
+
+## Transformations
+
+| Step | Input | Output |
+|------|-------|--------|
+| Title default | empty / missing title, filename | sanitized filename-based title |
+| Caption default | empty caption, EXIF camera | `Photo taken with {camera}` or `""` |
+| publishedAt | process time | ISO date `YYYY-MM-DD` (upload day) |
+| enrichmentStatus | new record | `pending` |
+| draft | new upload | `false` unless explicitly set (U1 supports field) |
+| featured | S3 metadata / init | boolean |
+
+## Integration points (logical)
+
+| System | Interaction |
+|--------|-------------|
+| Tickets API | Allocate numeric id |
+| S3 uploads | Source object + metadata |
+| S3 images | Store optimized variants + original key refs |
+| DynamoDB | Photo persistence |
+| Enrichment queue | Message after successful put (U2 consumer) |
+| Auth (HMAC) | Browser PATCH only |
+| IAM | Process Lambda DynamoDB/S3/tickets access |

--- a/aidlc-docs/construction/u1-photo-data-plane/functional-design/business-rules.md
+++ b/aidlc-docs/construction/u1-photo-data-plane/functional-design/business-rules.md
@@ -1,0 +1,66 @@
+# U1 — Business Rules
+
+## Identity & time
+
+| ID | Rule |
+|----|------|
+| BR-U1-01 | Photo primary key is ticket-allocated `id` (string form of integer for API stability). |
+| BR-U1-02 | Every write sets `updatedAt` (ISO-8601). Create also sets `createdAt`. |
+| BR-U1-03 | `publishedAt` is the publish calendar date (`YYYY-MM-DD`) at process time (not EXIF capture date). |
+
+## Visibility & enrichment
+
+| ID | Rule |
+|----|------|
+| BR-U1-04 | New successful process writes use `enrichmentStatus = pending`. |
+| BR-U1-05 | Pending photos are **publicly listable and gettable** (may lack tags/geo until U2). |
+| BR-U1-06 | Public list/get **omit** records with `draft = true`. Authenticated get may include drafts. |
+
+## Defaults
+
+| ID | Rule |
+|----|------|
+| BR-U1-07 | If title missing/blank → sanitized filename (strip extension; humanize separators). |
+| BR-U1-08 | If caption missing/blank → `Photo taken with {camera}` when EXIF camera present; else `""`. |
+| BR-U1-09 | New uploads default `draft = false` unless init metadata explicitly sets draft (if supported later). |
+
+## Listing & featured
+
+| ID | Rule |
+|----|------|
+| BR-U1-10 | Public list sort: `publishedAt` DESC, then `id` DESC. |
+| BR-U1-11 | Pagination: `limit` + opaque cursor (not offset pages). |
+| BR-U1-12 | Featured: newest photo with `featured = true`; if none, newest photo overall among non-drafts. |
+
+## Process integrity
+
+| ID | Rule |
+|----|------|
+| BR-U1-13 | If image optimize fails → do not allocate id (or ignore id if already attempted) and **do not** write DynamoDB. |
+| BR-U1-14 | If ticket allocation fails → **do not** write DynamoDB. |
+| BR-U1-15 | Successful persist **must not** create or commit `content/posts/**/index.md`. |
+| BR-U1-16 | Image keys (`folderName`, cover/original paths) are stored on the record for CDN URL construction. |
+
+## Auth
+
+| ID | Rule |
+|----|------|
+| BR-U1-17 | Process Lambda persists with **IAM** only (no HMAC). |
+| BR-U1-18 | Browser/owner `PATCH` requires valid photo-upload **HMAC token** (same family as `/upload`). |
+| BR-U1-19 | Public `GET` endpoints require no auth. |
+
+## Updates (PATCH)
+
+| ID | Rule |
+|----|------|
+| BR-U1-20 | Allowed patch fields in U1: `title`, `caption`, `tags`, `featured`, `draft` (and optionally `publishedAt` if needed — default **no** unless later unit). |
+| BR-U1-21 | PATCH must not change `id`, image keys, or precise GPS fields (GPS owned by enrichment). |
+| BR-U1-22 | Unknown photo id → not-found error to client. |
+| BR-U1-23 | Invalid/expired token → unauthorized. |
+
+## Errors
+
+| ID | Rule |
+|----|------|
+| BR-U1-24 | Validation errors on PATCH (empty title after trim, invalid types) → 400-class error with message. |
+| BR-U1-25 | Process failures are logged; no partial photo row on optimize/ticket failure. |

--- a/aidlc-docs/construction/u1-photo-data-plane/functional-design/domain-entities.md
+++ b/aidlc-docs/construction/u1-photo-data-plane/functional-design/domain-entities.md
@@ -1,0 +1,61 @@
+# U1 — Domain Entities
+
+## Photo (aggregate root)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string (numeric) | PK; from tickets |
+| `title` | string | required after defaults |
+| `caption` | string | single field for detail/listings; may be `""` |
+| `publishedAt` | string (`YYYY-MM-DD`) | publish date |
+| `createdAt` | string (ISO-8601) | immutable after create |
+| `updatedAt` | string (ISO-8601) | bump on write |
+| `featured` | boolean | homepage eligibility |
+| `draft` | boolean | public queries exclude when true |
+| `tags` | string[] | may be empty until U2 |
+| `enrichmentStatus` | `pending` \| `complete` \| `failed` | U1 writes `pending` |
+| `folderName` | string | CDN path segment |
+| `coverImageKey` / `originalKey` | string | object keys or relative names as designed in infra |
+| `exif` | object | camera, lens, aperture, shutterSpeed, iso, focalLength, dateTaken, width, height, format |
+| `latitude` / `longitude` | number \| null | precise; null in U1 until U2 |
+| `publicLatitude` / `publicLongitude` | number \| null | fuzzed; null until U2 |
+| `category` | string | default e.g. `Photography` |
+
+### Invariants
+- `id` unique and immutable
+- Public DTO never includes precise `latitude`/`longitude` (even when null/set later)
+- Non-draft + exists ⇒ eligible for public get/list
+
+## PublicPhotoDTO
+
+Subset for anonymous clients:
+
+- `id`, `title`, `caption`, `publishedAt`, `featured`, `tags`, `folderName`, cover URL fields, `exif` (non-GPS), `publicLatitude`, `publicLongitude`, `enrichmentStatus`
+
+## ListPage
+
+- `items: PublicPhotoDTO[]`
+- `cursor: string | null` (null ⇒ no more pages)
+- `limit: number`
+
+## UploadProcessContext (transient)
+
+- S3 bucket/key, content type  
+- User metadata: title, caption, featured  
+- Derived: buffer, exif, image keys, allocated id  
+
+Not persisted as its own entity.
+
+## AuthToken (existing)
+
+- HMAC session from passcode exchange  
+- Used only for authenticated HTTP writes in U1  
+
+## Relationships
+
+```text
+UploadProcessContext --creates--> Photo
+AuthToken --authorizes update--> Photo
+Photo --projected as--> PublicPhotoDTO
+ListPage --contains--> PublicPhotoDTO[]
+```

--- a/aidlc-docs/construction/u1-photo-data-plane/infrastructure-design/deployment-architecture.md
+++ b/aidlc-docs/construction/u1-photo-data-plane/infrastructure-design/deployment-architecture.md
@@ -1,0 +1,70 @@
+# U1 — Deployment Architecture
+
+## Runtime topology (us-east-1)
+
+```text
+Browser (later U3/U4)
+  | HTTPS
+  v
+API Gateway HTTP API (PhotoApi) ---- api.micahwalter.com/photos
+  |  GET list|featured|{id}
+  |  PATCH {id}  (HMAC)
+  |  POST auth, upload-url (existing)
+  v
+Lambda (same zip: auth, init, read, patch, process)
+  |
+  +--> DynamoDB micahwalter-photos (+ GSI1)
+  +--> Secrets Manager photo-upload-secrets
+  +--> S3 uploads (presign) / S3 images (optimize)
+  +--> Tickets API (HTTPS)
+  +--> EventBridge (PhotoPendingEnrichment)  .... U2 consumer later
+  |
+S3 ObjectCreated (uploads/incoming/)
+  --> Process Lambda
+        OnFailure --> SQS photo-upload-process-dlq
+```
+
+### Text alternative
+
+1. Browser calls Photo API on the shared custom domain.  
+2. Read/patch handlers use DynamoDB `micahwalter-photos`.  
+3. Upload still presigns to the uploads bucket; S3 invokes Process.  
+4. Process writes DynamoDB, emits EventBridge event, never commits to GitHub.  
+5. Process async failures land on an SQS DLQ after retries.
+
+---
+
+## Deploy pipeline
+
+| Step | Mechanism |
+|------|-----------|
+| Build zip | Existing `infra/photo-upload-lambdas` Makefile |
+| Upload artifact | S3 `micahwalter-newsletter-artifacts` / `photo-upload/lambda` |
+| Stack update | CloudFormation `micahwalter-photo-upload` via `.github/workflows/photo-upload-deploy.yml` (or manual deploy) |
+| Secret | No change required for U1 beyond existing passcode/hmac/ticketsPasscode |
+
+## IAM highlights (ProcessFn)
+
+- `dynamodb:PutItem`, `GetItem`, `UpdateItem`, `Query` on `micahwalter-photos` + GSI  
+- `events:PutEvents` on photo bus / source  
+- Existing S3 read uploads + write images  
+- Existing secrets read (without needing GitHub token in code)  
+- Network egress for tickets HTTPS  
+
+## IAM highlights (read/patch handlers)
+
+- DynamoDB read (and UpdateItem for PATCH)  
+- Secrets read for HMAC verify (patch only)  
+
+## Environments
+
+| Env | Notes |
+|-----|-------|
+| Production | us-east-1 stack as today |
+| Local | Next.js later calls prod/dev API URL via env; no local DynamoDB required for U1 backend work |
+
+## Rollback
+
+- Redeploy previous Lambda zip + CFN template revision.  
+- DynamoDB table/data remains (PITR available).  
+- Restoring markdown commit behavior requires redeploying pre-U1 process code (accepted; no dual-write).

--- a/aidlc-docs/construction/u1-photo-data-plane/infrastructure-design/infrastructure-design.md
+++ b/aidlc-docs/construction/u1-photo-data-plane/infrastructure-design/infrastructure-design.md
@@ -1,0 +1,110 @@
+# U1 — Infrastructure Design
+
+**Stack**: Extend `micahwalter-photo-upload` (`infra/photo-upload.yml` + `infra/photo-upload-lambdas/`)  
+**Region**: us-east-1  
+
+---
+
+## Logical → AWS mapping
+
+| Logical component | AWS / impl |
+|-------------------|------------|
+| PhotoStore | DynamoDB table `micahwalter-photos` + GSI1 |
+| PhotoHttpApi | API Gateway HTTP API routes on existing Photo API + handlers in same Lambda zip |
+| ProcessWorker | Existing `ProcessFn` Lambda (behavior change) + **async failure Destination → SQS DLQ** |
+| TicketClient | HTTPS to `api.micahwalter.com/tickets` (unchanged) |
+| ImageOptimizer | Existing sharp optimize → `micahwalter-www-images` |
+| EnrichmentQueuePublisher | **EventBridge** `PutEvents` on a photo bus (U2 adds rule/target) |
+| AuthVerifier | Existing HMAC token lib + Secrets Manager `photo-upload-secrets` |
+| PublicDtoProjector | In-process mapping in read handlers |
+
+---
+
+## DynamoDB — `micahwalter-photos`
+
+| Attribute | Role |
+|-----------|------|
+| `id` (S) | Partition key |
+| `gsi1pk` (S) | GSI1 PK — constant `"PHOTO"` for public listings |
+| `gsi1sk` (S) | GSI1 SK — `{publishedAt}#{id}` (ISO date + id) |
+| remaining Photo fields | As domain entity (title, caption, tags, draft, featured, exif map, keys, enrichmentStatus, timestamps, …) |
+
+**Billing**: On-demand  
+**PITR**: **Enabled**  
+**GSI1**: Projection ALL (or INCLUDE needed list fields — prefer ALL for U1 simplicity)  
+**Query**: `gsi1pk = PHOTO`, `ScanIndexForward=false`, exclusive start key from cursor  
+
+**Featured**: Query newest N from GSI1 among non-draft; prefer first with `featured=true`, else first item (app-level; optional sparse GSI later).
+
+---
+
+## EventBridge — enrichment handoff
+
+| Resource | Purpose |
+|----------|---------|
+| Event bus (e.g. `photo-bus` or default bus with source `micahwalter.photos`) | Process emits `PhotoPendingEnrichment` after PutItem |
+| Detail | `{ "photoId": "<id>" }` |
+| Rule / target | **Stub in U1** (rule may log or no target); **U2** attaches enricher Lambda |
+
+Best-effort: PutEvents failure logged; photo remains `pending`.
+
+---
+
+## Process failure DLQ
+
+| Resource | Purpose |
+|----------|---------|
+| SQS queue e.g. `photo-upload-process-dlq` | Lambda asynchronous invocation **OnFailure** destination for ProcessFn |
+| Retention | ≥14 days recommended |
+
+S3 → Lambda remains direct; platform retries then DLQ.
+
+---
+
+## API Gateway routes (additions)
+
+Existing: `POST /photos/auth`, `POST /photos/upload-url`  
+
+**U1 add** (same HTTP API / mapping key `photos`):
+
+| Method | Path | Auth |
+|--------|------|------|
+| GET | `/photos` | none (list; query `limit`, `cursor`) |
+| GET | `/photos/featured` | none |
+| GET | `/photos/{id}` | none |
+| PATCH | `/photos/{id}` | HMAC token (header/body as existing patterns) |
+
+Handlers live in the **same deployable zip** as auth/init/process (new entrypoints or router).
+
+---
+
+## Process Lambda changes
+
+1. After optimize + ticket id → `PutItem` to `micahwalter-photos` (`enrichmentStatus=pending`, defaults per FD).  
+2. `PutEvents` enrichment event (best effort).  
+3. **Remove** GitHub commit path and GitHub API usage from process.  
+4. IAM: add DynamoDB read/write, `events:PutEvents`; remove GitHub-related secret usage from process code (secret may still hold unused `githubToken` until cleaned).  
+5. Configure failure Destination → process DLQ.
+
+Init Lambda: accept/pass **caption** (and title/featured) as S3 object metadata for process (U3 UI will send; U1 API contract ready).
+
+---
+
+## Unchanged shared resources (referenced, not redesigned)
+
+- `api.micahwalter.com` (`infra/api-domain.yml`)  
+- Tickets API / `post_tickets`  
+- Uploads bucket `micahwalter-photo-uploads`  
+- Images bucket `micahwalter-www-images`  
+- Lambda artifacts bucket `micahwalter-newsletter-artifacts`  
+- Secrets Manager `photo-upload-secrets` (passcode, hmac, ticketsPasscode; githubToken unused by process after U1)
+
+---
+
+## Out of scope for U1 infra
+
+- Enrichment consumer Lambda + Bedrock/Location (U2)  
+- Multi-region / global tables (U7)  
+- CloudFront in front of photo API  
+- Galleries table (U6)  
+- Frontend Next.js hosting changes (U3/U4)

--- a/aidlc-docs/construction/u1-photo-data-plane/nfr-design/logical-components.md
+++ b/aidlc-docs/construction/u1-photo-data-plane/nfr-design/logical-components.md
@@ -1,0 +1,73 @@
+# U1 — Logical Components
+
+Minimal set (Q6=A). Infrastructure binding → Infrastructure Design.
+
+---
+
+## PhotoStore
+
+- **Role**: Persistence port for Photo aggregate  
+- **Ops**: put, update, getById, listByPublishedAt (cursor), getFeatured  
+- **NFR**: on-demand DynamoDB; GSI for list sort  
+
+## PhotoHttpApi
+
+- **Role**: HTTP boundary for public GET + authenticated PATCH  
+- **Depends on**: PhotoStore, AuthVerifier, PublicDtoProjector  
+- **NFR**: no response CDN cache; CORS as today  
+
+## ProcessWorker
+
+- **Role**: S3 ObjectCreated handler — optimize → ticket → put → enqueue  
+- **Depends on**: ImageOptimizer, TicketClient, PhotoStore, EnrichmentQueuePublisher  
+- **NFR**: fail-closed on optimize/ticket; **DLQ** on repeated failure; IAM only  
+
+## TicketClient
+
+- **Role**: Allocate numeric photo id via tickets API  
+- **NFR**: network errors fail process (no DDB row)  
+
+## ImageOptimizer
+
+- **Role**: Produce CDN variants + original key refs  
+- **NFR**: failure fails process before persist  
+
+## EnrichmentQueuePublisher
+
+- **Role**: Send `{ photoId }` (or equivalent) after successful put  
+- **NFR**: best-effort; log on failure; does not delete photo  
+
+## AuthVerifier
+
+- **Role**: Validate HMAC token for PATCH  
+- **NFR**: reject invalid/expired; unused by ProcessWorker  
+
+## PublicDtoProjector
+
+- **Role**: Map Photo → PublicPhotoDTO  
+- **NFR**: never emit precise latitude/longitude  
+
+---
+
+## Explicitly not in U1 logical set
+
+| Component | Reason |
+|-----------|--------|
+| IdempotencyGuard | Not selected (Q6=A); Lambda/S3 retry + DLQ instead |
+| CursorCodec (named) | Cursor encoding lives inside PhotoStore/PhotoHttpApi |
+| In-memory featured cache | Not selected (Q4=A) |
+| Enrichment consumer | U2 |
+
+## Component collaboration
+
+```text
+S3 event -> ProcessWorker
+             |-> ImageOptimizer
+             |-> TicketClient
+             |-> PhotoStore.put
+             |-> EnrichmentQueuePublisher (best effort)
+             +-> DLQ on terminal failure
+
+Client GET  -> PhotoHttpApi -> PhotoStore -> PublicDtoProjector
+Client PATCH -> PhotoHttpApi -> AuthVerifier -> PhotoStore
+```

--- a/aidlc-docs/construction/u1-photo-data-plane/nfr-design/nfr-design-patterns.md
+++ b/aidlc-docs/construction/u1-photo-data-plane/nfr-design/nfr-design-patterns.md
@@ -1,0 +1,48 @@
+# U1 — NFR Design Patterns
+
+**Decisions**: Q1=C, Q2=A, Q3=A, Q4=A, Q5=A, Q6=A
+
+---
+
+## Resilience
+
+### Fail-closed persist + DLQ for process
+- Optimize or ticket failure → **no DynamoDB write** (functional BR-U1-13/14).
+- Configure **process Lambda failure destination (DLQ)** so poison S3 events / repeated failures are inspectable (Q1=C).
+- Rely on Lambda/S3 native retries before DLQ; no custom in-process retry loops beyond platform defaults.
+
+### Best-effort enrichment enqueue
+- After successful `PutItem`, publish to enrichment queue.
+- If enqueue fails → **log and continue**; photo stays `enrichmentStatus=pending` for U2/manual redrive (Q2=A).
+- Do not roll back the photo row on enqueue failure.
+
+## Scalability
+
+### On-demand serverless
+- DynamoDB **on-demand** capacity mode.
+- Lambda **default concurrency** (no reserved concurrency on process in U1) (Q3=A).
+- Horizontal scale implicit via Lambda/API Gateway; personal traffic envelope from NFR-U1-S1.
+
+## Performance
+
+### GSI list/featured access
+- Primary key: `id`.
+- GSI for newest-first listing: partition suitable for “all public photos” (e.g. constant `gsi1pk=PHOTO`) + sort `publishedAt`/`id` (exact key schema in Infrastructure Design).
+- Featured: query/filter newest `featured=true`, else newest overall — **no in-memory cache** component (Q4=A).
+- Cursor pagination encoded from GSI keys (implementation detail; no separate CursorCodec component required in U1).
+
+## Security
+
+### Token verify + DTO projection + least privilege
+- Shared **AuthVerifier** (`assertAuth`) on PATCH routes only (Q5=A).
+- **PublicDtoProjector** strips precise GPS and internal-only fields.
+- Each Lambda role: least privilege (DDB table/GSI, S3 paths, tickets invoke/HTTPS, queue send for process only).
+- No extra API Gateway body-size limits mandated in U1 (can add later).
+
+## Cross-cutting
+
+| Pattern | Applied |
+|---------|---------|
+| CQRS-lite | Separate read DTOs vs command/process writes |
+| Async handoff | Queue publisher after persist (consumer = U2) |
+| Defense in depth | IAM (process) + HMAC (browser) + DTO filter |

--- a/aidlc-docs/construction/u1-photo-data-plane/nfr-requirements/nfr-requirements.md
+++ b/aidlc-docs/construction/u1-photo-data-plane/nfr-requirements/nfr-requirements.md
@@ -1,0 +1,70 @@
+# U1 — NFR Requirements
+
+**Unit**: Photo data plane  
+**Decisions from**: `u1-photo-data-plane-nfr-requirements-plan.md`
+
+---
+
+## Scalability
+
+| ID | Requirement |
+|----|-------------|
+| NFR-U1-S1 | Design for **personal / low traffic**: tens of uploads/day, low thousands of reads/day. |
+| NFR-U1-S2 | On-demand DynamoDB and Lambda concurrency defaults are sufficient; no provisioned autoscaling complexity in U1. |
+| NFR-U1-S3 | Multi-region scale-out is **out of scope for U1** (see U7 / NFR-3). |
+
+## Performance
+
+| ID | Requirement |
+|----|-------------|
+| NFR-U1-P1 | **Best effort** latency — no hard SLO. Soft goal: warm p95 GET list/get/featured under ~500ms. |
+| NFR-U1-P2 | Cold starts documented as acceptable; no provisioned concurrency required in U1. |
+| NFR-U1-P3 | Default list `limit=12`, maximum `limit=50` (cursor pagination per functional design). |
+
+## Caching
+
+| ID | Requirement |
+|----|-------------|
+| NFR-U1-C1 | **No CDN/API response caching** in U1 — API Gateway → Lambda → DynamoDB direct. |
+| NFR-U1-C2 | Future Cache-Control / CloudFront for GETs may be added in a later unit if needed. |
+
+## Availability
+
+| ID | Requirement |
+|----|-------------|
+| NFR-U1-A1 | Deploy in **us-east-1** primary, matching current `micahwalter-photo-upload` posture. |
+| NFR-U1-A2 | No DynamoDB global tables in U1. |
+| NFR-U1-A3 | Process path: fail closed on optimize/ticket errors (no partial rows) — availability of “correctness” over partial publish. |
+
+## Security
+
+| ID | Requirement |
+|----|-------------|
+| NFR-U1-SEC1 | Public GET endpoints are unauthenticated. |
+| NFR-U1-SEC2 | Owner PATCH requires existing photo-upload **HMAC** token. |
+| NFR-U1-SEC3 | Process Lambda uses **IAM** role only for DynamoDB/S3/tickets. |
+| NFR-U1-SEC4 | Public DTOs must not expose precise GPS (fields null until U2; never leak precise coords). |
+| NFR-U1-SEC5 | Secrets remain in Secrets Manager (`photo-upload-secrets`); not in git or logs. |
+| NFR-U1-SEC6 | No additional API Gateway rate limiting required in U1 (can revisit later). |
+
+## Reliability & observability
+
+| ID | Requirement |
+|----|-------------|
+| NFR-U1-R1 | CloudWatch logs for new/updated Lambdas; rely on API Gateway and Lambda basic metrics (4xx/5xx). |
+| NFR-U1-R2 | No new SNS alarms required in U1. |
+| NFR-U1-R3 | Process and API errors logged with enough context to debug (message + key ids when available). |
+
+## Maintainability
+
+| ID | Requirement |
+|----|-------------|
+| NFR-U1-M1 | Extend existing photo-upload Lambda package layout and CFN stack rather than a parallel stack. |
+| NFR-U1-M2 | Keep HTTP contracts simple JSON suitable for `lib/photos-api.ts` in U4. |
+
+## Usability (API consumer)
+
+| ID | Requirement |
+|----|-------------|
+| NFR-U1-U1 | Predictable cursor pagination and featured semantics matching site behavior. |
+| NFR-U1-U2 | CORS continues to allow production www and local dev origins as today. |

--- a/aidlc-docs/construction/u1-photo-data-plane/nfr-requirements/tech-stack-decisions.md
+++ b/aidlc-docs/construction/u1-photo-data-plane/nfr-requirements/tech-stack-decisions.md
@@ -1,0 +1,30 @@
+# U1 — Tech Stack Decisions
+
+## Confirmed stack
+
+| Concern | Choice | Rationale |
+|---------|--------|-----------|
+| Runtime | **Node.js** (existing photo-upload Lambdas) | Reuse exif/optimize/auth code; plan locked Node |
+| API | **API Gateway HTTP API** on `api.micahwalter.com/photos` | Extend `micahwalter-photo-upload` |
+| Data store | **Amazon DynamoDB** (on-demand) | Photo metadata; personal traffic |
+| Auth | Existing **passcode → HMAC** lib | PATCH only; process uses IAM |
+| AWS SDK | **AWS SDK v3** for JS | Match current Lambda deps style |
+| Region | **us-east-1** | Match current stack |
+| IaC | **CloudFormation** (`infra/photo-upload.yml` + lambda package) | Existing deploy path |
+| Tickets | Existing **tickets HTTPS API** | id allocation |
+| Queues (enqueue only) | SQS/EventBridge **stub/contract** for enrichment message | Full enricher is U2; U1 must enqueue after put |
+
+## Explicitly deferred
+
+| Item | Defer to |
+|------|----------|
+| DynamoDB global tables / multi-region | U7 |
+| API CDN caching / CloudFront on GETs | Later / if needed |
+| Bedrock + AWS Location | U2 |
+| API Gateway custom throttles | Later |
+| SNS alarms | Later |
+
+## Pagination defaults
+
+- `limit` default **12**, max **50**
+- Opaque cursor; sort `publishedAt` DESC, `id` DESC

--- a/aidlc-docs/inception/application-design/application-design.md
+++ b/aidlc-docs/inception/application-design/application-design.md
@@ -1,0 +1,80 @@
+# Application Design — Issues #103 / #104 (Consolidated)
+
+**Branch**: `cursor/photo-metadata-dynamodb-be02`  
+**Artifacts**: [components](./components.md) · [methods](./component-methods.md) · [services](./services.md) · [dependencies](./component-dependency.md)
+
+---
+
+## Design Summary
+
+Migrate photo (and gallery) metadata to DynamoDB behind an extended `api.micahwalter.com/photos` API on the existing photo-upload stack (Node.js). Uploads persist quickly, then enrich asynchronously (Bedrock tags + AWS Location reverse geocode). The static Next.js site loads photo data via `lib/photos-api.ts`. Owner admin lives primarily under `/upload`, with an Edit shortcut on `/photos/[id]`. Public URLs move to `/photos/<id>` with legacy redirects. Feeds update via a scheduled job.
+
+## Locked Decisions
+
+| Topic | Choice |
+|-------|--------|
+| API / stack | Extend `micahwalter-photo-upload` |
+| Language | Node.js |
+| Enrichment | Async queue after pending persist |
+| Frontend | `lib/photos-api.ts` + client fetch |
+| Admin UX | `/upload` hub primary; detail Edit shortcut; galleries on hub |
+| Geocode | AWS Location Service (cache on photo) |
+| Static map | Provider deferred (port in design) |
+| Components | Proposed set accepted |
+
+## Component Map
+
+```text
+                    +------------------+
+                    |   PhotosCLI      |
+                    +--------+---------+
+                             |
++-------------+   HTTPS    +--v------------------+   SDK   +----------------+
+| PhotoAdminUI| ---------> | Photo Metadata API  | -------> | PhotoRepository|
+| PhotoPublicUI|           | (Gateway + Lambdas) | -------> | GalleryRepository|
++------+------+            +----+-----+----+-----+         +----------------+
+       |                        |     |    |
+  lib/photos-api                |     |    +--> EnrichmentService --> Bedrock
+                                |     |                           --> AWS Location
+                         Process|     |Query/Command
+                                v     v
+                         S3 uploads / images CDN
+                                |
+                         FeedPublisher (schedule)
+                                |
+                         RedirectLayer (CloudFront)
+```
+
+## Services (orchestration)
+
+1. **Photo Metadata API** — auth, CRUD photos/galleries, public reads  
+2. **Upload & Process** — S3 → optimize → id → pending record → enqueue  
+3. **Enrichment** — GPS fuzz, Location city/country tags, Bedrock tags  
+4. **Public / Admin UI** — Next.js + photos-api helpers  
+5. **Feed Publisher** — scheduled RSS/sitemap photo updates  
+6. **CLI** — import/tag via API  
+
+## Coverage vs Requirements / Stories
+
+| Area | Design coverage |
+|------|-----------------|
+| FR-1–3 Store/API | PhotoRepository, Command/Query services |
+| FR-2 Enrichment | EnrichmentService + async pipeline |
+| FR-4–6 UI upload/browse | PhotoAdminUI, PhotoPublicUI |
+| FR-5 Redirects | RedirectLayer |
+| FR-7 Edit | PhotoCommandService + AdminUI shortcut |
+| FR-8 Galleries | Gallery* components + hub admin |
+| FR-9 Feeds/search | FeedPublisher + PhotoQueryService search |
+| FR-10 CLI | PhotosCLI |
+| FR-11 Cutover | Process drops GitHub commit; migration in Units/Construction |
+| US-001–016 | Mapped across services above |
+
+## Out of Scope Here
+
+- DynamoDB key/GSI details, fuzz radius, map tile provider → Functional / NFR / Infrastructure Design  
+- Exact HTTP path list and OpenAPI → Units / Code Generation  
+- Dual-write duration and migration runbook → Units / Cutover unit  
+
+## Next Stage
+
+**Units Generation** — decompose into implementable units along the execution-plan critical path.

--- a/aidlc-docs/inception/application-design/component-dependency.md
+++ b/aidlc-docs/inception/application-design/component-dependency.md
@@ -1,0 +1,70 @@
+# Component Dependencies — Issues #103 / #104
+
+---
+
+## Dependency Matrix
+
+| Component | Depends on |
+|-----------|------------|
+| PhotoCommandService | PhotoRepository, Auth/token lib, Tickets (create path via process) |
+| PhotoQueryService | PhotoRepository |
+| GalleryAdminService | GalleryRepository, Auth |
+| GalleryQueryService | GalleryRepository, PhotoRepository (or PhotoQueryService for summaries) |
+| UploadProcessPipeline | S3, optimize lib, Tickets API, PhotoRepository / PhotoCommandService, Enrichment queue |
+| EnrichmentService | PhotoRepository, S3/images, Bedrock, AWS Location |
+| PhotoAdminUI | `lib/photos-api.ts` → Command/Query/Gallery APIs, Auth |
+| PhotoPublicUI | `lib/photos-api.ts` → Query/Gallery APIs |
+| RedirectLayer | Photo id set (migrated ids / numeric heuristic + allowlist) |
+| FeedPublisher | PhotoQueryService or PhotoRepository |
+| PhotosCLI | Photo APIs (auth) |
+
+---
+
+## Communication Patterns
+
+| From → To | Pattern |
+|-----------|---------|
+| Browser → API Gateway | HTTPS JSON (CORS for www + localhost) |
+| Init → S3 | Presigned PUT |
+| S3 → Process | Event notification |
+| Process → Enrichment | Async queue (SQS preferred) |
+| Process/Enrichment → DynamoDB | AWS SDK |
+| Enrichment → Bedrock / Location | AWS SDK |
+| Process → Tickets | HTTPS |
+| FeedPublisher → S3 website/artifacts | SDK put |
+| CF → RedirectLayer | CloudFront Function / behavior |
+
+---
+
+## Data Flow (upload → public)
+
+```text
+Owner (AdminUI)
+  -> auth + upload-url (title, caption, featured)
+  -> S3 PUT original
+  -> Process: optimize + id + DynamoDB pending + enqueue
+  -> Enrichment: GPS fuzz + Location city/country tags + Bedrock tags
+  -> DynamoDB complete
+Visitor (PublicUI)
+  -> lib/photos-api get/list/featured
+  -> PhotoQueryService (fuzzed DTO)
+  -> render /photos/[id] (+ static map if public geo)
+```
+
+---
+
+## Data Flow (legacy URL)
+
+```text
+Visitor -> GET /posts/156
+  -> RedirectLayer 301 -> /photos/156
+  -> PhotoPublicUI -> API getPhoto(156)
+```
+
+---
+
+## Coupling notes
+
+- **Tight**: Process ↔ Repository; Enrichment ↔ Repository; UI ↔ photos-api helpers
+- **Loose**: FeedPublisher (schedule); RedirectLayer (edge); CLI (same HTTP contracts)
+- **External**: Tickets, Bedrock, AWS Location, S3 images CDN (unchanged layout initially)

--- a/aidlc-docs/inception/application-design/component-methods.md
+++ b/aidlc-docs/inception/application-design/component-methods.md
@@ -1,0 +1,118 @@
+# Component Methods — Issues #103 / #104
+
+High-level signatures only. Detailed business rules → Functional Design (per unit).
+
+---
+
+## PhotoRepository
+
+| Method | Input | Output | Purpose |
+|--------|-------|--------|---------|
+| `putPhoto(photo)` | PhotoRecord | void | Insert/overwrite photo |
+| `updatePhoto(id, patch)` | id, partial fields | PhotoRecord | Partial update |
+| `getPhoto(id)` | id | PhotoRecord \| null | Load by id |
+| `listPhotos(query)` | pagination, filters | { items, cursor } | Newest-first list |
+| `getFeaturedPhoto()` | — | PhotoRecord \| null | Newest featured, else newest |
+| `searchPhotos(q, query)` | text + pagination | { items, cursor } | Title/caption/tags search |
+
+## GalleryRepository
+
+| Method | Input | Output | Purpose |
+|--------|-------|--------|---------|
+| `putGallery(gallery)` | GalleryRecord | void | Create/overwrite |
+| `updateGallery(id, patch)` | id, patch | GalleryRecord | Rename / membership |
+| `getGallery(idOrSlug)` | id or slug | GalleryRecord \| null | Load one |
+| `listGalleries()` | — | GalleryRecord[] | Admin/public list |
+
+## PhotoCommandService
+
+| Method | Input | Output | Purpose |
+|--------|-------|--------|---------|
+| `createFromUpload(meta)` | title, caption, featured, folderName, imageKeys, exif… | PhotoRecord | Persist after process |
+| `updateMetadata(id, patch, token)` | id, fields, auth | PhotoRecord | Owner edit |
+| `assertAuth(token)` | token | void / throw | Validate HMAC session |
+
+## PhotoQueryService
+
+| Method | Input | Output | Purpose |
+|--------|-------|--------|---------|
+| `getPublicPhoto(id)` | id | PublicPhotoDTO | Detail DTO (fuzzed geo) |
+| `listPublicPhotos(query)` | pagination | page of PublicPhotoDTO | `/photos` grid |
+| `getFeaturedPublic()` | — | PublicPhotoDTO \| null | Homepage hero |
+| `searchPublic(q, query)` | text + page | page of PublicPhotoDTO | Live search |
+
+## GalleryAdminService
+
+| Method | Input | Output | Purpose |
+|--------|-------|--------|---------|
+| `createGallery(input, token)` | name/slug, token | GalleryRecord | Create |
+| `renameGallery(id, name, token)` | … | GalleryRecord | Rename |
+| `setMembership(id, photoIds[], token)` | ordered ids | GalleryRecord | Replace order |
+| `addPhoto` / `removePhoto` | id, photoId, token | GalleryRecord | Incremental edits |
+
+## GalleryQueryService
+
+| Method | Input | Output | Purpose |
+|--------|-------|--------|---------|
+| `getPublicGallery(slug)` | slug | Gallery with photo summaries | Public page |
+| `listPublicGalleries()` | — | summaries | Index |
+
+## UploadProcessPipeline
+
+| Method | Input | Output | Purpose |
+|--------|-------|--------|---------|
+| `handleObjectCreated(event)` | S3 event | void | Main handler |
+| `optimizeAndStore(buffer, folder)` | bytes, folder | imageKeys | CDN variants + original |
+| `allocateId()` | — | id | Tickets API |
+| `persistPending(record)` | PhotoRecord | void | Fast write |
+| `enqueueEnrichment(id)` | id | void | SQS/EventBridge |
+
+## EnrichmentService
+
+| Method | Input | Output | Purpose |
+|--------|-------|--------|---------|
+| `enrich(id)` | photo id | void | Full enrichment pass |
+| `extractOrLoadExif(photo)` | record / S3 | exif+gps | Ensure EXIF |
+| `fuzzCoordinates(lat, lon)` | precise | publicLat/Lon | Privacy |
+| `reverseGeocode(lat, lon)` | precise | { city, country } | AWS Location |
+| `tagWithBedrock(imageRef)` | image | string[] | Vision tags |
+| `mergeTags(...tagSets)` | arrays | string[] | Dedupe merge |
+
+## PhotoAdminUI / PhotoPublicUI (Next.js)
+
+| Surface | Key behaviors |
+|---------|----------------|
+| Upload hub | Multi-file select; per-file fields; progress; call init + PUT + poll/status as designed |
+| Edit shortcut | On `/photos/[id]` when authed → open editor for that id |
+| Gallery admin | CRUD membership UI on hub |
+| Public pages | Call `lib/photos-api.ts` helpers; render caption/map conditionally |
+
+### `lib/photos-api.ts` (shared client)
+
+| Function | Purpose |
+|----------|---------|
+| `getPhoto(id)` | Public detail |
+| `listPhotos(params)` | Paginated list |
+| `getFeaturedPhoto()` | Hero |
+| `searchPhotos(q, params)` | Search |
+| `updatePhoto(id, patch, token)` | Auth write |
+| `listGalleries` / `getGallery` / gallery admin helpers | Galleries |
+
+## RedirectLayer
+
+| Method | Purpose |
+|--------|---------|
+| `resolveLegacyPostPath(path)` | If numeric photo id → 301 to `/photos/<id>` |
+
+## FeedPublisher
+
+| Method | Purpose |
+|--------|---------|
+| `runScheduledPublish()` | Rebuild photo feed/sitemap fragments from API/DB |
+
+## PhotosCLI
+
+| Command mapping | Purpose |
+|-----------------|---------|
+| `photos:import` | Upload/register via API |
+| `photos:tag` | Trigger/retag enrichment via API |

--- a/aidlc-docs/inception/application-design/components.md
+++ b/aidlc-docs/inception/application-design/components.md
@@ -1,0 +1,84 @@
+# Components — Issues #103 / #104
+
+**Scope**: Photo metadata DynamoDB migration + dynamic serving  
+**Plan decisions**: Extend photo-upload stack; Node.js; async enrichment; `lib/photos-api.ts`; `/upload` hub + detail Edit shortcut; AWS Location reverse geocode; proposed component set
+
+---
+
+## PhotoRepository
+
+- **Purpose**: Persist and retrieve photo metadata in DynamoDB
+- **Responsibilities**: CRUD for photo records; query by publishedAt, featured; support search/filter fields used by PhotoQueryService
+- **Interfaces**: Internal data-access API used by command/query/enrichment services (not HTTP-facing)
+
+## GalleryRepository
+
+- **Purpose**: Persist gallery definitions and ordered photo membership
+- **Responsibilities**: Create/rename galleries; add/remove/reorder photo ids; load gallery by slug/id
+- **Interfaces**: Internal data-access API for GalleryAdminService / GalleryQueryService
+
+## PhotoCommandService
+
+- **Purpose**: Authenticated writes to photo metadata
+- **Responsibilities**: Create photo record (from process pipeline); update title/caption/tags/featured; validate auth token
+- **Interfaces**: HTTP under `api.micahwalter.com/photos` (authenticated mutations); invoked by UploadProcessPipeline and admin UI
+
+## PhotoQueryService
+
+- **Purpose**: Public (and cacheable) photo reads
+- **Responsibilities**: Get by id; list/paginate; featured; search/filter; strip precise GPS from public DTOs (expose fuzzed coords only)
+- **Interfaces**: HTTP GET under `api.micahwalter.com/photos`
+
+## GalleryAdminService
+
+- **Purpose**: Authenticated gallery management
+- **Responsibilities**: Create/rename galleries; mutate membership order; auth gate
+- **Interfaces**: HTTP under `api.micahwalter.com/photos/galleries` (or equivalent admin paths)
+
+## GalleryQueryService
+
+- **Purpose**: Public gallery reads
+- **Responsibilities**: List galleries; get gallery with resolved photo summaries for UI
+- **Interfaces**: HTTP GET under `api.micahwalter.com/photos/galleries`
+
+## UploadProcessPipeline
+
+- **Purpose**: Handle S3 ObjectCreated for incoming uploads
+- **Responsibilities**: Download original; optimize variants to images bucket; allocate ticket id; write initial photo record (status pending/enriching); enqueue enrichment; **do not** commit GitHub markdown
+- **Interfaces**: S3 event trigger; calls PhotoCommandService / PhotoRepository; emits enrichment message
+
+## EnrichmentService
+
+- **Purpose**: Async post-upload enrichment
+- **Responsibilities**: Ensure EXIF/GPS on record; fuzz public coordinates; AWS Location reverse geocode → city/country tags; Bedrock vision tags; merge tags; update enrichment status; failures logged without deleting photo
+- **Interfaces**: SQS/EventBridge consumer; uses PhotoRepository; AWS Location; Bedrock
+
+## PhotoAdminUI
+
+- **Purpose**: Owner-facing Next.js admin surfaces
+- **Responsibilities**: `/upload` hub — multi-file upload (per-file title/caption/featured + progress), photo edit list/forms, gallery admin; `/photos/[id]` authenticated Edit shortcut into hub/editor for that photo; passcode auth
+- **Interfaces**: Browser → photo APIs via `lib/photos-api.ts` (auth writes)
+
+## PhotoPublicUI
+
+- **Purpose**: Visitor-facing photo surfaces
+- **Responsibilities**: Homepage hero + recent photos; `/photos` grid; `/photos/[id]` detail (caption, tags, EXIF, static map when public geo present); public galleries; live search integration for photos
+- **Interfaces**: Browser → PhotoQueryService / GalleryQueryService via `lib/photos-api.ts`
+
+## RedirectLayer
+
+- **Purpose**: Preserve legacy photo URLs
+- **Responsibilities**: Permanent redirect `/posts/<photo-id>` → `/photos/<photo-id>` for migrated photo ids; leave blog slugs untouched
+- **Interfaces**: CloudFront Function and/or static redirect artifacts
+
+## FeedPublisher
+
+- **Purpose**: Keep feeds current without full site rebuild
+- **Responsibilities**: Scheduled job reads photo API/DB; updates RSS and/or sitemap photo entries with `/photos/<id>` URLs
+- **Interfaces**: EventBridge schedule → Lambda; writes to feed artifacts location (S3/site bucket or agreed path)
+
+## PhotosCLI
+
+- **Purpose**: Desktop parity for import/retag
+- **Responsibilities**: `blog photos:import` / `photos:tag` against API/DB (no markdown as source of truth)
+- **Interfaces**: CLI → authenticated photo APIs

--- a/aidlc-docs/inception/application-design/services.md
+++ b/aidlc-docs/inception/application-design/services.md
@@ -1,0 +1,103 @@
+# Services — Issues #103 / #104
+
+Service layer = orchestration across components (HTTP Lambdas, pipelines, jobs, UI).
+
+---
+
+## Photo Metadata API Service (extended `micahwalter-photo-upload`)
+
+**Stack**: Existing photo-upload CloudFormation + new routes/Lambdas (Node.js)  
+**Base path**: `https://api.micahwalter.com/photos`
+
+### Responsibilities
+- Auth (existing passcode → token) shared by upload, edit, gallery admin
+- Presigned upload init (extended metadata: title, caption, featured per file)
+- Public read APIs (query)
+- Authenticated write APIs (command)
+- Gallery admin + public gallery APIs
+- Own DynamoDB tables (photos, galleries) in this stack
+- IAM for DynamoDB, Bedrock, AWS Location (enricher), S3
+
+### Orchestration
+```text
+Browser AdminUI --auth--> Auth Lambda
+Browser AdminUI --init--> Init Lambda --> S3 presign (title, caption, featured metadata)
+Browser --> S3 PUT
+S3 event --> Process Lambda --> optimize --> tickets --> PhotoRepository.put (pending)
+                      --> enqueue Enrichment
+Enrichment Lambda --> EnrichmentService --> PhotoRepository.update
+Browser PublicUI --> PhotoQueryService / GalleryQueryService
+Browser AdminUI --> PhotoCommandService / GalleryAdminService
+```
+
+---
+
+## Upload & Process Service
+
+**Components**: UploadProcessPipeline, PhotoRepository, tickets client, image optimize  
+**Trigger**: S3 ObjectCreated on uploads bucket  
+
+**Flow**
+1. Read object + S3 metadata (title, caption, featured)
+2. Optimize → images bucket
+3. Allocate id via tickets API
+4. Persist photo (enrichmentStatus=`pending`)
+5. Enqueue enrichment message
+6. Never GitHub-commit markdown
+
+---
+
+## Enrichment Service (async)
+
+**Components**: EnrichmentService, PhotoRepository, Bedrock, AWS Location  
+**Trigger**: SQS (or EventBridge) from process  
+
+**Flow**
+1. Load photo + image
+2. EXIF/GPS if needed
+3. Fuzz public coordinates when GPS present
+4. Reverse geocode → merge city/country into tags
+5. Bedrock tags → merge
+6. Set enrichmentStatus=`complete` or `failed` (photo remains published)
+
+---
+
+## Photo Public Experience Service (Next.js)
+
+**Components**: PhotoPublicUI, `lib/photos-api.ts`, RedirectLayer (edge)  
+**Hosting**: Static export shells + client fetch  
+
+**Flow**
+- Page load → helpers → PhotoQueryService
+- Detail renders caption, tags, EXIF, static map URL from public geo (map provider later)
+- Search uses live photo search endpoint
+
+---
+
+## Photo Admin Experience Service (Next.js)
+
+**Components**: PhotoAdminUI, `lib/photos-api.ts`  
+
+**Flow**
+- `/upload` hub: unlock → multi-upload | edit list | galleries
+- `/photos/[id]`: if owner session present → Edit shortcut → hub editor for id
+- All mutations via authenticated APIs
+
+---
+
+## Feed Publisher Service
+
+**Components**: FeedPublisher  
+**Trigger**: EventBridge schedule  
+
+**Flow**
+1. Query recent/all public photos
+2. Update RSS/sitemap artifacts with `/photos/<id>`
+3. No full Next.js rebuild
+
+---
+
+## CLI Service
+
+**Components**: PhotosCLI  
+**Flow**: Local commands authenticate and call the same APIs as admin UI for import/tag.

--- a/aidlc-docs/inception/application-design/unit-of-work-dependency.md
+++ b/aidlc-docs/inception/application-design/unit-of-work-dependency.md
@@ -1,0 +1,42 @@
+# Unit of Work Dependencies — Issues #103 / #104
+
+## Sequence (strict)
+
+```text
+U1 Photo data plane
+  -> U2 Enrichment
+    -> U3 Upload UI
+      -> U4 Browse & detail
+        -> U5 Edit UI
+          -> U6 Galleries
+            -> U7 Cutover
+```
+
+## Dependency matrix
+
+| Unit | Depends on | Blocks | Shared contracts |
+|------|------------|--------|------------------|
+| U1 | — (tickets, S3, existing auth) | U2–U7 | PhotoRecord schema; GET/PATCH `/photos`; process persist |
+| U2 | U1 | Soft: richer U4/U5 tags/map | enrichmentStatus; tags; publicLat/Lon |
+| U3 | U1 | U5 (hub), U7 upload path | init metadata: title, caption, featured; multi presign |
+| U4 | U1 | U5 shortcut, U6 public, U7 redirects verify | `lib/photos-api.ts`; `/photos/[id]` route; CF redirects |
+| U5 | U1, U3, U4 | — | updateMetadata API |
+| U6 | U1, U3, U4 | U7 gallery migration verify | GalleryRecord; gallery APIs |
+| U7 | U1–U6 | — | Migration idempotency; feed artifact paths; CLI auth |
+
+## Integration checkpoints
+
+| After | Validate |
+|-------|----------|
+| U1 | API smoke: put/get/list/featured; process write without markdown commit |
+| U2 | Enrichment message → tags + fuzzed geo on record |
+| U3 | Multi-upload e2e to API |
+| U4 | Homepage/`/photos`/detail/search from API; redirect spot-check |
+| U5 | Edit persists and shows on public detail |
+| U6 | Gallery admin + public page |
+| U7 | Migrated ids live; feeds job; CLI; content cleanup dry-run |
+
+## Rollback notes
+
+- **U1–U6**: Redeploy previous Lambda/UI; DynamoDB data may remain (safe). Markdown no longer written — rollback to markdown requires restoring old process code (accepted risk; no dual-write).
+- **U7**: Keep migration reversible until content folders deleted; delete markdown only after verification checklist passes.

--- a/aidlc-docs/inception/application-design/unit-of-work-story-map.md
+++ b/aidlc-docs/inception/application-design/unit-of-work-story-map.md
@@ -1,0 +1,52 @@
+# Unit ↔ Story Map — Issues #103 / #104
+
+**Stories source**: `aidlc-docs/inception/user-stories/issue-103-stories.md`  
+**Coverage target**: US-001 … US-016 — all assigned
+
+---
+
+## Map by unit
+
+| Unit | Stories | Notes |
+|------|---------|-------|
+| **U1 Photo data plane** | US-002 | Persist to DynamoDB; no git commit; API readable |
+| **U2 Enrichment** | US-003, US-004 | Bedrock tags; GPS fuzz + Location city/country tags |
+| **U3 Upload UI** | US-001 | Multi-file + per-file title/caption/featured |
+| **U4 Browse & detail** | US-007, US-008, US-009, US-010 | Live API browse/detail/search; `/photos/<id>`; redirects |
+| **U5 Edit UI** | US-005 | Auth edit + detail shortcut |
+| **U6 Galleries** | US-011, US-012 | Admin UI + public galleries + markdown migrate |
+| **U7 Cutover** | US-006, US-013, US-014, US-015, US-016 | CLI; migrate photos; cleanup; feeds job; multi-region |
+
+---
+
+## Map by story
+
+| Story | Title (short) | Unit |
+|-------|---------------|------|
+| US-001 | Multi-file upload metadata | U3 |
+| US-002 | Persist without git commit | U1 |
+| US-003 | Auto AI tags | U2 |
+| US-004 | GPS enrichment / fuzz / city-country tags | U2 |
+| US-005 | Authenticated edit UI | U5 |
+| US-006 | CLI import/tag against API | U7 |
+| US-007 | Browse from live API | U4 |
+| US-008 | Detail `/photos/<id>` | U4 |
+| US-009 | Legacy redirects | U4 |
+| US-010 | Live search photos | U4 |
+| US-011 | Gallery admin UI | U6 |
+| US-012 | Public galleries from DB | U6 |
+| US-013 | Migrate existing photos | U7 |
+| US-014 | Stop markdown + clean content tree | U7 |
+| US-015 | Scheduled RSS/sitemap | U7 |
+| US-016 | Multi-region parity | U7 |
+
+---
+
+## Coverage check
+
+| Check | Status |
+|-------|--------|
+| All 16 stories assigned | Yes |
+| No story in two units | Yes |
+| FR-1…11 touched via story→unit chain | Yes (via requirements traceability in stories) |
+| Journey order respected | Yes (publish → enrich → browse → edit → galleries → cutover) |

--- a/aidlc-docs/inception/application-design/unit-of-work.md
+++ b/aidlc-docs/inception/application-design/unit-of-work.md
@@ -1,0 +1,110 @@
+# Units of Work — Issues #103 / #104
+
+**Decomposition**: 7 journey-aligned units, strict sequential, no dual-write, each unit deployable/demoable  
+**Plan**: `aidlc-docs/inception/plans/issue-103-unit-of-work-plan.md`  
+**Application design**: `aidlc-docs/inception/application-design/`
+
+---
+
+## U1 — Photo data plane
+
+| | |
+|--|--|
+| **Type** | Service / Module (API + persistence + process write path) |
+| **Responsibility** | DynamoDB `photos` table; public read + authenticated write APIs on `api.micahwalter.com/photos`; process Lambda persists to DynamoDB and **does not** commit GitHub markdown |
+| **Components** | PhotoRepository, PhotoCommandService, PhotoQueryService, UploadProcessPipeline (persist path), Auth |
+| **Deliverable / demo** | Create/get/list/featured via API; process path writes a pending photo record without markdown |
+| **Stories** | US-002 (foundation) |
+| **Construction** | Functional Design, NFR, Infrastructure Design, Code Generation |
+
+---
+
+## U2 — Enrichment
+
+| | |
+|--|--|
+| **Type** | Service (async worker) |
+| **Responsibility** | SQS/EventBridge enricher: GPS fuzz, AWS Location reverse geocode → city/country tags, Bedrock vision tags; update photo enrichment status |
+| **Components** | EnrichmentService, PhotoRepository; Bedrock; AWS Location |
+| **Deliverable / demo** | Pending photo becomes enriched (tags + public geo fields) without blocking upload ACK |
+| **Stories** | US-003, US-004 |
+| **Depends on** | U1 |
+| **Construction** | Functional Design, NFR, Infrastructure Design, Code Generation |
+
+---
+
+## U3 — Upload UI
+
+| | |
+|--|--|
+| **Type** | Module (Next.js admin) |
+| **Responsibility** | Multi-file `/upload` hub section: per-file title, caption, featured, progress; passcode auth; calls extended init/upload APIs |
+| **Components** | PhotoAdminUI (upload), `lib/photos-api.ts` (upload helpers as needed) |
+| **Deliverable / demo** | Owner uploads multiple photos with captions; records appear via U1 APIs |
+| **Stories** | US-001 |
+| **Depends on** | U1 (U2 optional for seeing tags later) |
+| **Construction** | Functional Design (light), Code Generation; Infra N/A unless new env vars only |
+
+---
+
+## U4 — Browse & detail
+
+| | |
+|--|--|
+| **Type** | Module (Next.js public) |
+| **Responsibility** | `lib/photos-api.ts`; homepage hero/recent; `/photos`; `/photos/[id]` (caption, EXIF, static map port); live search; legacy redirects `/posts/<id>` → `/photos/<id>` |
+| **Components** | PhotoPublicUI, RedirectLayer, photos-api client |
+| **Deliverable / demo** | www shows API-backed photos at new URLs; old photo links redirect |
+| **Stories** | US-007, US-008, US-009, US-010 |
+| **Depends on** | U1 (enrichment fields graceful if missing) |
+| **Construction** | Functional Design (map port), NFR (client fetch), Infrastructure Design (CF redirects), Code Generation |
+
+---
+
+## U5 — Edit UI
+
+| | |
+|--|--|
+| **Type** | Module (Next.js admin) |
+| **Responsibility** | Hub photo editor; authenticated Edit shortcut on `/photos/[id]`; update title/caption/tags/featured via API |
+| **Components** | PhotoAdminUI (edit), PhotoCommandService (already in U1) |
+| **Deliverable / demo** | Owner edits metadata; public pages reflect changes without deploy |
+| **Stories** | US-005 |
+| **Depends on** | U1, U3 (hub), U4 (detail shortcut) |
+| **Construction** | Functional Design (light), Code Generation |
+
+---
+
+## U6 — Galleries
+
+| | |
+|--|--|
+| **Type** | Service + Module |
+| **Responsibility** | DynamoDB galleries; hub admin UI; public gallery pages; migrate `content/galleries` markdown |
+| **Components** | GalleryRepository, GalleryAdminService, GalleryQueryService, PhotoAdminUI (galleries), PhotoPublicUI (galleries) |
+| **Deliverable / demo** | Create gallery in hub; public gallery renders API photos |
+| **Stories** | US-011, US-012 |
+| **Depends on** | U1, U3, U4 |
+| **Construction** | Functional Design, NFR, Infrastructure Design, Code Generation |
+
+---
+
+## U7 — Cutover
+
+| | |
+|--|--|
+| **Type** | Cross-cutting cutover / ops |
+| **Responsibility** | Migrate ~43 photos; content tree cleanup; feed scheduler; CLI parity; multi-region parity; verify no markdown photo source of truth |
+| **Components** | Migration scripts, FeedPublisher, PhotosCLI, infra multi-region wiring |
+| **Deliverable / demo** | Full site on DB photos; feeds update on schedule; CLI import/tag against API; photo folders removable |
+| **Stories** | US-006, US-013, US-014, US-015, US-016 |
+| **Depends on** | U1–U6 |
+| **Construction** | Functional Design (migration rules), NFR, Infrastructure Design, Code Generation |
+
+---
+
+## Sequencing policy
+
+1. Complete each unit (design → code → smoke/demo) before starting the next.  
+2. No dual-write: from U1 onward, process writes DynamoDB only.  
+3. Single owner approves each unit gate.

--- a/aidlc-docs/inception/plans/issue-103-application-design-clarifications.md
+++ b/aidlc-docs/inception/plans/issue-103-application-design-clarifications.md
@@ -1,0 +1,99 @@
+# Issue #103 / #104 — Application Design Clarifications
+
+Thank you for the answers. Three items need a clearer lock before we approve the design plan and generate artifacts.
+
+**Already clear**
+
+| Q | Locked |
+|---|--------|
+| 1 | Extend existing `micahwalter-photo-upload` / `/photos` API |
+| 2 | Node.js for new photo metadata Lambdas |
+| 3 | Async enrichment via SQS/EventBridge after fast persist |
+| 7 | Static map provider deferred (`StaticMap` port only in App Design) |
+| 8 | Accept proposed component set |
+
+---
+
+## Clarification 1 — Frontend data access (your Q4: “Need more info”)
+
+With **hybrid hosting**, the public site is still static HTML on S3. Photo data lives in DynamoDB behind `api.micahwalter.com`. Something in the browser (or a tiny helper) must call that API. The options differ only in *how we organize that fetch*:
+
+| Option | What it means in practice |
+|--------|---------------------------|
+| **A — Client-side fetch only** | Each page (or component) calls `fetch('https://api.micahwalter.com/photos/...')` directly. Simple, but fetch URLs/headers may get duplicated. |
+| **B — Thin helpers (`lib/photos-api.ts`)** | One shared module exports `getPhoto(id)`, `listPhotos()`, `getFeatured()`, etc. Pages import those helpers. **Same runtime behavior as A**, just cleaner code — recommended default for this repo. |
+| **C — Build-time fallback + client refresh** | Optionally bake empty/placeholder HTML at build; always refresh from API when the page loads. More moving parts; only useful if you want non-JS fallbacks. |
+
+### Clarification Question 1
+
+Which frontend access pattern should we design for?
+
+A) Client-side `fetch` scattered in components (no shared helper required)
+
+B) Shared `lib/photos-api.ts` (or similar) wrappers — **recommended**
+
+C) Build-time placeholder + always refresh from API on load
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B
+
+---
+
+## Clarification 2 — Admin UI (your Q5: “A + C”)
+
+You want both:
+
+- **A** — `/upload` as a Photos admin hub (upload | edit | galleries)
+- **C** — Edit controls on `/photos/[id]` when authenticated
+
+That hybrid is fine if we define the rule:
+
+### Clarification Question 2
+
+How should A + C work together?
+
+A) **Hub is primary; detail page has a shortcut** — Full upload / multi-edit / gallery admin live under `/upload` (or `/upload/*`). On `/photos/[id]`, an authenticated owner sees an “Edit” control that opens the hub editor (or inline fields) for that photo only. Galleries are only managed from the hub.
+
+B) **Detail page is primary for single-photo edit; hub for batch + galleries** — `/photos/[id]` has full inline edit when authed. `/upload` hub handles multi-upload + gallery admin (+ optional list of photos to jump into edit).
+
+C) **Everything on the hub only** — Drop per-detail edit for v1 (revisit later); you meant A as the real choice.
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+## Clarification 3 — AWS Location Service costs (your Q6: “B — but let me know the costs”)
+
+You chose **AWS Location Service** for reverse geocoding. For this site’s volume, cost is typically **negligible**:
+
+| Item | Cost picture | Your likely usage |
+|------|--------------|-------------------|
+| Reverse geocode (Places **Core**) | Pay-per-request; AWS publishes bucket pricing on the [Location pricing page](https://aws.amazon.com/location/pricing/). Historically Core Places calls are on the order of **tens of cents per 1,000 requests** — check the live table for your region. | ~1 call per GPS photo on upload |
+| Free tier note | Location free tier has included on the order of **20,000 Core Geocode/Reverse Geocode requests/month for 3 months** for eligible accounts (see current Free Tier table). | Backfill + early usage often fits free tier if eligible |
+| Backfill ~43 photos | Likely **well under $1** even outside free tier | One-time |
+| Ongoing | Tens of GPS uploads/month → typically **cents/month** | Ongoing |
+| Storing results | If you persist place labels long-term, use the API’s intended-use / Stored bucket where required — may cost more per call; we should cache city/country on the photo record and avoid repeat calls | Design will cache on photo |
+| Static maps | Separate from reverse-geocode; Q7 defers map provider | — |
+
+**Bottom line for this site:** AWS Location reverse-geocode cost should be **negligible** (pennies to low dollars/year at your volume). Complexity cost (IAM, Place Index in CFN) is the real tradeoff vs Nominatim.
+
+### Clarification Question 3
+
+After seeing the cost picture, confirm reverse geocode provider:
+
+A) **Stay with AWS Location Service** (recommended given low volume + AWS-native IAM)
+
+B) **Switch to Nominatim / OSM** (free; rate-limit carefully)
+
+C) **Defer provider** — design a `Geocoder` port only; pick in Infrastructure Design
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+When all three answers are filled, reply here and we will lock the Application Design plan for your approval before generating design docs.

--- a/aidlc-docs/inception/plans/issue-103-application-design-plan.md
+++ b/aidlc-docs/inception/plans/issue-103-application-design-plan.md
@@ -1,0 +1,201 @@
+# Issue #103 / #104 — Application Design Plan
+
+**Purpose**: Identify components, service orchestration, methods, and dependencies for the photo metadata migration.  
+**Requirements**: `aidlc-docs/inception/requirements/issue-103-requirements.md`  
+**Stories**: `aidlc-docs/inception/user-stories/issue-103-stories.md`  
+**Execution plan**: `aidlc-docs/inception/plans/issue-103-execution-plan.md`
+
+Please answer every `[Answer]:` below. After validation (and any clarifications), you will **approve this plan**, then design artifacts will be generated under `aidlc-docs/inception/application-design/`.
+
+---
+
+
+
+## Design questions
+
+
+
+### Question 1 — Where does the photo/gallery API live?
+
+A) **Extend existing photo-upload stack** — Add DynamoDB + read/write/gallery routes on `api.micahwalter.com/photos` (and `/photos/galleries` or similar) in `micahwalter-photo-upload`
+
+B) **New sibling stack** — e.g. `micahwalter-photos` for metadata/read APIs; keep upload auth/init/process in the current stack but have process call the new data plane
+
+C) **Split by concern** — Upload stack owns writes/enrichment; new read-optimized stack owns public GET + feed job
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 2 — Lambda language for new photo metadata APIs
+
+A) **Node.js** — Match existing `infra/photo-upload-lambdas/` (faster reuse of process/exif code)
+
+B) **Go** — Match newsletter/tickets stacks (`infra/newsletter-lambdas/`, ticket server)
+
+C) **Hybrid** — Keep process/enrichment in Node; implement new public read + admin APIs in Go
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 3 — Enrichment execution model
+
+A) **Inline in process Lambda** — After optimize + PutItem, call Bedrock + reverse-geocode in the same invocation (simpler; longer timeout)
+
+B) **Async follow-up** — Process writes a `pending` record quickly; SQS/EventBridge triggers an enricher Lambda for tags/geo (better upload latency)
+
+C) **Inline tags, async geo** — Bedrock in process; reverse-geocode async (or vice versa)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B
+
+---
+
+
+
+### Question 4 — Frontend data access pattern
+
+A) **Client-side fetch only** — Browser calls `api.micahwalter.com` from homepage/`/photos`/`/photos/[id]` (static shells)
+
+B) **Thin BFF helpers** — Small client modules in `lib/photos-api.ts` wrapping fetch; pages are client components or hydrate from client
+
+C) **Build-time fallback + client refresh** — Optional static placeholder; always refresh from API on load
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: Need more info on what this is
+
+**Clarified → B** — Shared `lib/photos-api.ts` helpers (see clarifications file)
+
+---
+
+
+
+### Question 5 — Admin UI placement (edit + gallery admin)
+
+A) **Under** `/upload` **hub** — Expand upload area into an authenticated “Photos admin” (upload | edit | galleries)
+
+B) **Separate** `/admin/photos` **routes** — Dedicated admin section (`noindex`); upload stays at `/upload`
+
+C) **Per-photo edit on detail page** — Owner sees edit controls on `/photos/[id]` when authed; galleries at `/admin/galleries`
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A + C
+
+**Clarified → Hub primary + detail shortcut** — Full admin under `/upload` hub; `/photos/[id]` has authenticated Edit shortcut for that photo; galleries only on hub
+
+---
+
+
+
+### Question 6 — Reverse geocode provider
+
+A) **OpenStreetMap Nominatim** (or similar free HTTP API) with caching/rate limits
+
+B) **AWS Location Service**
+
+C) **Decide in Infrastructure Design** — Application Design only requires a `Geocoder` port/interface
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B - but let me know the costs
+
+**Clarified → A (stay with AWS Location Service)** — low volume; cost negligible; cache city/country on photo record
+
+---
+
+
+
+### Question 7 — Static map provider
+
+A) **Static OSM/tile URL pattern** (e.g. staticmap or similar open service)
+
+B) **Mapbox Static Images API** (token in env)
+
+C) **Decide in Infrastructure / NFR Design** — Design only requires a `StaticMap` URL builder port
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: C
+
+---
+
+
+
+### Question 8 — Component boundary preference
+
+A) **Proposed defaults below** — Accept the component list in “Proposed component set” (adjust later only if needed)
+
+B) **Fewer, larger components** — Collapse read/write into one PhotosService; fewer files
+
+C) **More granular** — Separate Enrichment, Geocoding, Tagging, FeedPublisher as first-class components in the design docs
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+## Proposed component set (for Question 8 / generation)
+
+
+| Component             | Responsibility (high level)                                  |
+| --------------------- | ------------------------------------------------------------ |
+| PhotoRepository       | DynamoDB persistence for photos                              |
+| GalleryRepository     | DynamoDB persistence for galleries                           |
+| PhotoCommandService   | Create/update photo metadata; auth writes                    |
+| PhotoQueryService     | List/get/featured/search public reads                        |
+| GalleryAdminService   | Create/update gallery membership                             |
+| GalleryQueryService   | Public gallery reads                                         |
+| UploadProcessPipeline | S3 event → optimize → id → persist (orchestrates enrichment) |
+| EnrichmentService     | EXIF/GPS, fuzz, reverse-geocode tags, Bedrock tags           |
+| PhotoAdminUI          | Upload multi-file, edit, gallery admin (Next.js)             |
+| PhotoPublicUI         | Homepage/`/photos`/`/photos/[id]`/search/galleries (Next.js) |
+| RedirectLayer         | Legacy `/posts/<id>` → `/photos/<id>`                        |
+| FeedPublisher         | Scheduled RSS/sitemap photo updates                          |
+| PhotosCLI             | Import/tag against API                                       |
+
+
+---
+
+## Decisions locked (after clarifications)
+
+| Topic | Decision |
+|-------|----------|
+| API home | Extend `micahwalter-photo-upload` / `api.micahwalter.com/photos` |
+| Language | Node.js |
+| Enrichment | Async (SQS/EventBridge enricher after fast persist) |
+| Frontend access | `lib/photos-api.ts` thin helpers + client fetch |
+| Admin UI | `/upload` hub primary; `/photos/[id]` Edit shortcut when authed; galleries on hub only |
+| Reverse geocode | AWS Location Service (cache results on photo) |
+| Static map | Port only in App Design; provider in Infra/NFR Design |
+| Components | Proposed component set accepted |
+
+---
+
+## Generation checklist (after plan approval)
+
+- [x] Generate `aidlc-docs/inception/application-design/components.md`
+- [x] Generate `aidlc-docs/inception/application-design/component-methods.md`
+- [x] Generate `aidlc-docs/inception/application-design/services.md`
+- [x] Generate `aidlc-docs/inception/application-design/component-dependency.md`
+- [x] Generate `aidlc-docs/inception/application-design/application-design.md` (consolidated)
+- [x] Validate design completeness vs FR/US coverage
+- [x] Update `aidlc-state.md` and `audit.md`
+
+---
+
+When all answers are filled, reply in chat.

--- a/aidlc-docs/inception/plans/issue-103-execution-plan.md
+++ b/aidlc-docs/inception/plans/issue-103-execution-plan.md
@@ -1,0 +1,248 @@
+# Execution Plan — Issues #103 / #104: Photo Metadata DynamoDB + Dynamic Serving
+
+**GitHub Issues**: [#103](https://github.com/micahwalter/micahwalter-www/issues/103), [#104](https://github.com/micahwalter/micahwalter-www/issues/104)  
+**Branch**: `cursor/photo-metadata-dynamodb-be02`  
+**Date**: 2026-07-16  
+**Requirements**: `aidlc-docs/inception/requirements/issue-103-requirements.md`  
+**Stories**: `aidlc-docs/inception/user-stories/issue-103-stories.md`  
+**RE**: `aidlc-docs/inception/reverse-engineering/photo-subsystem.md`
+
+---
+
+## Detailed Analysis Summary
+
+### Transformation Scope (Brownfield)
+- **Transformation Type**: Architectural + infrastructure — photo metadata moves from git markdown to DynamoDB; photo UI becomes API-backed; upload process stops GitHub commits
+- **Primary Changes**: New photo/gallery data plane; process Lambda enrichment; hybrid frontend fetch; CloudFront redirects; scheduled feed job; content-tree cleanup
+- **Related Components**: `infra/photo-upload-*`, `infra/tickets.yml`, `infra/api-domain.yml`, `infra/infra.yml` (CF redirects), `app/upload`, `app/photos`, `app/posts`, `app/page`, `lib/content.ts`, `lib/galleries.ts`, `scripts/tag-photos.js`, `cli/`, `.github/workflows/*`
+
+### Change Impact Assessment
+| Area | Impact |
+|------|--------|
+| User-facing | Yes — multi-upload, captions, `/photos/<id>`, maps, edit UI, gallery admin, live listings |
+| Structural | Yes — new DB + APIs; hybrid static/dynamic photo surfaces |
+| Data model | Yes — DynamoDB photos + galleries; migrate ~43 photos + gallery markdown |
+| API | Yes — extend `/photos`; public read + authenticated write; gallery admin APIs |
+| NFR | Yes — publish latency, GPS privacy, multi-region parity, enrichment resilience |
+
+### Component Relationships
+```text
+tickets API (id alloc)
+    ^
+photo-upload process --> DynamoDB photos (+ enrichment: EXIF/GPS, Bedrock, reverse geocode)
+    |                         |
+    |                         +--> public read API --> homepage /photos /photos/[id] search
+    |                         +--> auth write API --> edit UI / upload metadata
+    +--> images CDN (unchanged)
+DynamoDB galleries <--> gallery admin UI / public gallery pages
+Scheduled job --> RSS/sitemap photo URLs
+CloudFront --> /posts/<id> photo redirects --> /photos/<id>
+```
+
+| Component | Change Type | Priority |
+|-----------|-------------|----------|
+| Photo DynamoDB + APIs | Major (new) | Critical |
+| photo-upload process Lambda | Major | Critical |
+| Next.js photo UI + upload/edit | Major | Critical |
+| Galleries store + admin/public | Major | Important |
+| CloudFront / redirects | Minor–Major | Critical |
+| Feed scheduled job | Major (new) | Important |
+| CLI photo tools | Minor–Major | Important |
+| Blog markdown / static export core | None / config only | — |
+
+### Risk Assessment
+- **Risk Level**: High
+- **Rollback Complexity**: Moderate–Difficult (dual-write window recommended before deleting markdown; redirects reversible)
+- **Testing Complexity**: Complex (API, UI, enrichment, migration, redirects, feeds)
+- **Mitigations**: Dual-write then cutover; idempotent migration; enrichment failures non-blocking; keep image CDN unchanged
+
+---
+
+## Phase Decisions
+
+| AI-DLC Stage | Decision | Rationale |
+|--------------|----------|-----------|
+| Workspace Detection | COMPLETED | Brownfield; new engagement on existing repo |
+| Reverse Engineering | COMPLETED | Focused photo-subsystem refresh |
+| Requirements Analysis | COMPLETED | Comprehensive; approved |
+| User Stories | COMPLETED | 16 stories / 2 personas; approved |
+| Workflow Planning | IN PROGRESS | This document |
+| Application Design | **EXECUTE** | New services, APIs, components, dependencies |
+| Units Generation | **EXECUTE** | Multiple packages/units; schemas + APIs + infra |
+| Functional Design | **EXECUTE** (per unit as needed) | Data models, enrichment rules, gallery membership |
+| NFR Requirements | **EXECUTE** (per unit as needed) | Latency, GPS privacy, multi-region, caching |
+| NFR Design | **EXECUTE** (per unit as needed) | Fuzzing, async enrichment, failover patterns |
+| Infrastructure Design | **EXECUTE** (per unit as needed) | DynamoDB, Lambdas, CF behaviors, scheduler |
+| Code Generation | **EXECUTE** (always, per unit) | Implementation |
+| Build and Test | **EXECUTE** (always) | Build, migration dry-run, manual/API verification |
+| Operations | PLACEHOLDER | Deploy handoff notes at end if needed |
+
+### Depth
+- Application Design / Units / per-unit design: **comprehensive** (matches migration complexity)
+- Code Generation: full planning + generation per unit
+
+---
+
+## Workflow Visualization
+
+```mermaid
+flowchart TD
+    Start(["Issues 103 104 Photo DB"])
+
+    subgraph INCEPTION["INCEPTION PHASE"]
+        WD["Workspace Detection<br/>COMPLETED"]
+        RE["Reverse Engineering<br/>COMPLETED"]
+        RA["Requirements Analysis<br/>COMPLETED"]
+        US["User Stories<br/>COMPLETED"]
+        WP["Workflow Planning<br/>IN PROGRESS"]
+        AD["Application Design<br/>EXECUTE"]
+        UG["Units Generation<br/>EXECUTE"]
+    end
+
+    subgraph CONSTRUCTION["CONSTRUCTION PHASE"]
+        FD["Functional Design<br/>EXECUTE per unit"]
+        NFRA["NFR Requirements<br/>EXECUTE per unit"]
+        NFRD["NFR Design<br/>EXECUTE per unit"]
+        ID["Infrastructure Design<br/>EXECUTE per unit"]
+        CG["Code Generation<br/>EXECUTE per unit"]
+        BT["Build and Test<br/>EXECUTE"]
+    end
+
+    subgraph OPERATIONS["OPERATIONS PHASE"]
+        OPS["Operations<br/>PLACEHOLDER"]
+    end
+
+    Start --> WD --> RE --> RA --> US --> WP --> AD --> UG
+    UG --> FD --> NFRA --> NFRD --> ID --> CG
+    CG -->|"next unit"| FD
+    CG --> BT --> EndNode(["Complete"])
+    BT -.-> OPS
+
+    style WD fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style RE fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style RA fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style US fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style WP fill:#FFA726,stroke:#E65100,stroke-width:3px,color:#000
+    style AD fill:#FFA726,stroke:#E65100,stroke-width:3px,stroke-dasharray: 5 5,color:#000
+    style UG fill:#FFA726,stroke:#E65100,stroke-width:3px,stroke-dasharray: 5 5,color:#000
+    style FD fill:#FFA726,stroke:#E65100,stroke-width:3px,stroke-dasharray: 5 5,color:#000
+    style NFRA fill:#FFA726,stroke:#E65100,stroke-width:3px,stroke-dasharray: 5 5,color:#000
+    style NFRD fill:#FFA726,stroke:#E65100,stroke-width:3px,stroke-dasharray: 5 5,color:#000
+    style ID fill:#FFA726,stroke:#E65100,stroke-width:3px,stroke-dasharray: 5 5,color:#000
+    style CG fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style BT fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style OPS fill:#BDBDBD,stroke:#424242,stroke-width:2px,stroke-dasharray: 5 5,color:#000
+    style Start fill:#CE93D8,stroke:#6A1B9A,stroke-width:3px,color:#000
+    style EndNode fill:#CE93D8,stroke:#6A1B9A,stroke-width:3px,color:#000
+```
+
+### Text alternative
+
+```text
+INCEPTION (done): Workspace Detection -> Reverse Engineering -> Requirements -> User Stories
+INCEPTION (next): Workflow Planning (this) -> Application Design -> Units Generation
+CONSTRUCTION (per unit): Functional Design -> NFR Requirements -> NFR Design -> Infrastructure Design -> Code Generation
+AFTER ALL UNITS: Build and Test -> Complete
+Operations: placeholder
+```
+
+---
+
+## Phases to Execute
+
+### INCEPTION
+- [x] Workspace Detection
+- [x] Reverse Engineering
+- [x] Requirements Analysis
+- [x] User Stories
+- [x] Workflow Planning (this document — awaiting approval)
+- [ ] Application Design — **EXECUTE**
+  - Rationale: New photo/gallery services, APIs, UI components, dependency map
+- [ ] Units Generation — **EXECUTE**
+  - Rationale: Multi-unit decomposition across data plane, enrichment, UI, galleries, cutover
+
+### CONSTRUCTION (per unit, then once)
+- [ ] Functional Design — **EXECUTE** when unit has data/business rules
+- [ ] NFR Requirements — **EXECUTE** when unit has latency/security/region concerns
+- [ ] NFR Design — **EXECUTE** when NFR Requirements ran
+- [ ] Infrastructure Design — **EXECUTE** when unit touches AWS resources
+- [ ] Code Generation — **EXECUTE** (always)
+- [ ] Build and Test — **EXECUTE** (after all units)
+
+### OPERATIONS
+- [ ] Operations — PLACEHOLDER (optional deploy handoff notes)
+
+### Skipped
+- None remaining in INCEPTION/CONSTRUCTION beyond adaptive per-unit skips (e.g. a pure UI unit may skip Infrastructure Design)
+
+---
+
+## Tentative Unit Sequence (finalize in Units Generation)
+
+Suggested critical path (subject to Units Generation approval):
+
+1. **Photo data plane** — DynamoDB photos, public read + auth write APIs, process Lambda writes DB (no GitHub commit), dual-write optional window
+2. **Enrichment** — GPS extract, fuzz, reverse-geocode → city/country tags, Bedrock auto-tags
+3. **Upload UI** — multi-file + per-file title/caption/featured + progress
+4. **Browse & detail** — homepage/`/photos`/`/photos/[id]` API fetch; static map; internal links
+5. **Edit UI** — authenticated metadata edit
+6. **Galleries** — DynamoDB + admin UI + public pages + migrate gallery markdown
+7. **Cutover** — migrate 43 photos, redirects `/posts/<id>`→`/photos/<id>`, feed scheduler, content cleanup, CLI parity, multi-region wiring
+
+**Update approach**: Sequential along critical path (1→2→3/4 can partially overlap after APIs exist); galleries after photos readable; cutover last.
+
+**Story mapping (indicative)**  
+- Unit 1: US-002 foundation  
+- Unit 2: US-003, US-004  
+- Unit 3: US-001  
+- Unit 4: US-007, US-008, US-009, US-010  
+- Unit 5: US-005  
+- Unit 6: US-011, US-012  
+- Unit 7: US-006, US-013–US-016  
+
+---
+
+## Package / Stack Change Sequence
+
+1. DynamoDB + photo API Lambdas (extend `micahwalter-photo-upload` or sibling stack) + IAM/Bedrock/geo permissions  
+2. Process Lambda behavior change (DB write, drop GitHub commit)  
+3. Frontend Next.js photo surfaces + upload/edit/gallery admin  
+4. CloudFront redirect rules for legacy photo URLs  
+5. Scheduled feed/sitemap job  
+6. Migration scripts + cutover + content cleanup  
+7. CLI updates  
+
+---
+
+## Scope Characterization (not calendar estimates)
+
+- **Stages remaining (INCEPTION)**: Application Design, Units Generation  
+- **Construction**: Up to ~7 units, each with design+code as applicable  
+- **Highest coupling**: Data plane must land before UI and cutover  
+- **Highest risk slice**: Cutover (migration + stop markdown + redirects)
+
+---
+
+## Success Criteria
+
+- **Primary goal**: Photos publish and render from DynamoDB/API without full site rebuild; markdown photo tree removed after cutover  
+- **Key deliverables**: Working APIs/UI per US-001–016 acceptance criteria; migration complete; redirects live; feed job running  
+- **Quality gates**: `npm run build` for site; API smoke tests; migration dry-run then apply; manual upload/edit/gallery/map checks  
+- **Integration**: Homepage, `/photos`, detail, search, galleries, legacy redirects consistent  
+- **Operational readiness**: Multi-region posture documented/implemented per NFR-3; secrets/IAM in place  
+
+---
+
+## Extension Compliance Summary
+
+| Extension | Status | Notes |
+|-----------|--------|-------|
+| Security Baseline | N/A (disabled) | Auth, secrets, GPS privacy still required by NFRs |
+| Resiliency Baseline | N/A (disabled) | Multi-region parity still required by NFR-3 |
+| Property-Based Testing | N/A (disabled) | Lightweight validation in Build and Test |
+
+---
+
+## Approval Gate
+
+Awaiting approval of this execution plan before **Application Design**.

--- a/aidlc-docs/inception/plans/issue-103-story-generation-plan.md
+++ b/aidlc-docs/inception/plans/issue-103-story-generation-plan.md
@@ -1,0 +1,146 @@
+# Issue #103 / #104 — Story Generation Plan
+
+**Purpose**: Convert approved requirements into INVEST user stories and personas.  
+**Requirements**: `aidlc-docs/inception/requirements/issue-103-requirements.md`  
+**Assessment**: `aidlc-docs/inception/plans/issue-103-user-stories-assessment.md`
+
+Please answer every `[Answer]:` below. When done, reply here (e.g. “done”). After answers are validated (and any clarifications resolved), you will be asked to **approve this plan** before stories are generated.
+
+---
+
+## Part 1 — Planning questions
+
+### Question 1 — Personas to model
+
+A) **Two personas** — Site Owner (upload/edit/admin) and Visitor (browse/detail)
+
+B) **Three personas** — Site Owner, Visitor, and “Returning Visitor with bookmarked `/posts/<id>` links” (legacy URL / redirect focus)
+
+C) **Owner only** — Stories focus on authoring; visitor behavior covered only as acceptance criteria on owner-facing epics
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 2 — Story breakdown approach
+
+A) **Epic-based** — Epics (Upload & Enrichment, Browse & Detail, Edit & Admin, Galleries, Cutover & Feeds) with small stories under each
+
+B) **User journey-based** — Stories ordered as journeys: “Publish a batch”, “Fix metadata”, “Visitor finds a photo”, “Build a gallery”, “Cut over from markdown”
+
+C) **Feature-based** — Flat list grouped by feature area without formal epics
+
+D) **Hybrid** — Epics for structure + one primary journey narrative per epic in the story description
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B
+
+---
+
+
+
+### Question 3 — Story granularity
+
+A) **Small / vertical** — Prefer stories that can be demoed end-to-end where possible (e.g. “upload one photo to DB and see it on `/photos`”) even if infrastructure is shared
+
+B) **Layered** — Separate backend/API stories from UI stories (faster parallel units; weaker solo demos)
+
+C) **Coarse** — Fewer, larger stories (one per epic) with detailed acceptance criteria
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 4 — Acceptance criteria style
+
+A) **Checklist** — Bullet “Given/When/Then or checkboxes” per story (repo’s prior AI-DLC style)
+
+B) **Gherkin** — Formal Given/When/Then scenarios only
+
+C) **Checklist + happy path Gherkin** — Bullets for edge cases; one Gherkin scenario for the happy path
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 5 — Cutover / migration stories
+
+A) **Include explicit cutover stories** — Migration of 43 photos, stop GitHub commits, delete markdown folders, redirects, dual-write end — as first-class stories
+
+B) **Fold into technical epics** — Mention cutover only inside related feature stories’ acceptance criteria
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 6 — Story ID / tracing
+
+A) **US-### with FR mapping** — e.g. `US-012` maps to `FR-2`, `NFR-1` in each story
+
+B) **US-### only** — Traceability via epic tags; no per-FR lines
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+## Decisions (locked from answers)
+
+| Q | Choice | Meaning |
+|---|--------|---------|
+| 1 | A | Personas: Site Owner + Visitor |
+| 2 | B | Journey-based story organization |
+| 3 | A | Small / vertical (demoable) stories |
+| 4 | A | Checklist acceptance criteria |
+| 5 | A | Explicit cutover/migration stories |
+| 6 | A | `US-###` with FR/NFR mapping per story |
+
+---
+
+## Part 2 — Generation checklist (execute only after plan approval)
+
+- [x] Generate `aidlc-docs/inception/user-stories/issue-103-personas.md` with approved personas
+- [x] Generate `aidlc-docs/inception/user-stories/issue-103-stories.md` using approved breakdown, granularity, and AC style
+- [x] Ensure each story follows INVEST and includes acceptance criteria
+- [x] Map personas to stories
+- [x] Cross-check coverage against FR-1…FR-11 and key NFRs in `issue-103-requirements.md`
+- [x] Update `aidlc-docs/aidlc-state.md` and `audit.md`
+
+---
+
+
+
+## Approach trade-offs (reference)
+
+
+| Approach      | Pros                            | Cons                          |
+| ------------- | ------------------------------- | ----------------------------- |
+| Epic-based    | Clear delivery slices for units | Can feel “system-centric”     |
+| Journey-based | Strong UAT narrative            | Harder to split infra work    |
+| Feature-based | Simple list                     | Weak sequencing for cutover   |
+| Hybrid        | Structure + narrative           | Slightly more doc to maintain |
+
+
+---
+
+When all answers are filled, reply in chat. Do **not** expect story files until this plan is approved after answer validation.

--- a/aidlc-docs/inception/plans/issue-103-unit-of-work-plan.md
+++ b/aidlc-docs/inception/plans/issue-103-unit-of-work-plan.md
@@ -1,0 +1,154 @@
+# Issue #103 / #104 — Unit of Work Plan
+
+**Purpose**: Decompose the photo metadata migration into ordered units of work for Construction.  
+**Inputs**: Requirements, stories US-001–016, application design, execution plan tentative sequence  
+
+Please answer every `[Answer]:` below. After validation and **plan approval**, artifacts will be generated:
+
+- `aidlc-docs/inception/application-design/unit-of-work.md`
+- `aidlc-docs/inception/application-design/unit-of-work-dependency.md`
+- `aidlc-docs/inception/application-design/unit-of-work-story-map.md`
+
+---
+
+## Proposed units (baseline from execution plan)
+
+
+| Unit | Name             | Focus                                                                                           | Stories (indicative) |
+| ---- | ---------------- | ----------------------------------------------------------------------------------------------- | -------------------- |
+| U1   | Photo data plane | DynamoDB photos, public read + auth write APIs, process writes DB (no GitHub commit)            | US-002 foundation    |
+| U2   | Enrichment       | Async queue, GPS fuzz, AWS Location city/country tags, Bedrock tags                             | US-003, US-004       |
+| U3   | Upload UI        | Multi-file `/upload` with per-file title/caption/featured + progress                            | US-001               |
+| U4   | Browse & detail  | `lib/photos-api.ts`, homepage/`/photos`/`/photos/[id]`, static map port, live search, redirects | US-007–010           |
+| U5   | Edit UI          | Hub editor + `/photos/[id]` Edit shortcut                                                       | US-005               |
+| U6   | Galleries        | DynamoDB galleries, hub admin, public galleries, migrate gallery markdown                       | US-011, US-012       |
+| U7   | Cutover          | Migrate 43 photos, stop markdown, content cleanup, feed job, CLI parity, multi-region           | US-006, US-013–016   |
+
+
+**Critical path (locked)**: U1 → U2 → U3 → U4 → U5 → U6 → U7 (**strict sequential**; no parallel overlap)
+
+---
+
+## Decisions locked
+
+| Q | Choice | Meaning |
+|---|--------|---------|
+| 1 | A | Keep 7-unit baseline |
+| 2 | A | Strict sequential unit completion |
+| 3 | A | No dual-write — DynamoDB only from U1 |
+| 4 | A | Single owner / approver for all units |
+| 5 | A | Each unit deployable/demoable when finished |
+| 6 | A | Journey-aligned unit boundaries |
+
+---
+
+## Planning questions (answered)
+
+
+
+### Question 1 — Story grouping / unit count
+
+A) **Accept the 7-unit baseline above**
+
+B) **Merge UI units** — Combine U3+U5 (all admin UI) and keep U4 public UI separate → 6 units
+
+C) **Merge enrichment into data plane** — U1 includes async enrichment (U2 removed) → 6 units
+
+D) **Fewer, larger units** — (1) Backend data+enrichment+process, (2) All frontend, (3) Cutover+feeds+CLI → 3 units
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 2 — Dependencies / sequencing
+
+A) **Strict sequential** — Finish each unit (design+code+smoke) before starting the next on the critical path
+
+B) **Pipeline with limited overlap** — After U1 APIs exist, allow U3 and U4 in parallel; U2 can overlap late U1 if contracts stable
+
+C) **Max parallel after U1** — Once read/write APIs land, run U2–U6 in parallel where possible; U7 last only
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 3 — Dual-write during U1
+
+A) **No dual-write** — Process writes DynamoDB only from the start of U1 (faster; harder rollback to markdown)
+
+B) **Short dual-write** — Process writes DynamoDB + still commits markdown until U7 cutover flag flips
+
+C) **Feature flag** — Env/flag chooses DB-only vs dual-write; default dual-write until U7
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 4 — Team / ownership (solo site)
+
+A) **Single owner for all units** — You review/approve each unit; no split ownership (default for this repo)
+
+B) **Logical ownership labels only** — Tag units Backend / Frontend / Cutover for doc clarity; still one implementer
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 5 — Deployability per unit
+
+A) **Each unit should be deployable/demoable** — e.g. U1 APIs live before UI; U4 can show API data even if upload UI unfinished
+
+B) **Backend units ship together** — U1+U2 before any frontend depends on enrichment fields
+
+C) **Hold public cutover to U7** — Earlier units can deploy to AWS, but www keeps markdown photos until U7
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+### Question 6 — Business domain boundaries
+
+A) **Align units to journeys** — Keep upload/enrich vs browse vs admin vs galleries vs cutover as separate units (matches baseline)
+
+B) **Align to bounded contexts only** — (1) Photo catalog, (2) Authoring, (3) Distribution/feeds — remap stories accordingly
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+## Generation checklist (after plan approval)
+
+- [x] Generate `unit-of-work.md` with unit definitions and responsibilities
+- [x] Generate `unit-of-work-dependency.md` with dependency matrix and sequence
+- [x] Generate `unit-of-work-story-map.md` mapping US-001–016 to units (100% coverage)
+- [x] Validate unit boundaries vs application design components
+- [x] Ensure all stories are assigned
+- [x] Update `aidlc-state.md` and `audit.md`
+
+---
+
+When all answers are filled, reply in chat.

--- a/aidlc-docs/inception/plans/issue-103-user-stories-assessment.md
+++ b/aidlc-docs/inception/plans/issue-103-user-stories-assessment.md
@@ -1,0 +1,23 @@
+# User Stories Assessment — Issues #103 / #104
+
+## Request Analysis
+- **Original Request**: Migrate photo metadata to DynamoDB; serve photos dynamically; multi-upload, captions, geo/map, AI tags; full cutover
+- **User Impact**: Direct — site owner (upload/edit/gallery admin) and visitors (browse/detail/map/legacy redirects)
+- **Complexity Level**: Complex
+- **Stakeholders**: Site owner (primary); visitors (secondary)
+
+## Assessment Criteria Met
+- [x] High Priority: New user-facing features (upload batch, edit UI, gallery admin, `/photos/<id>`, maps)
+- [x] High Priority: User experience changes (publish without deploy; new URL shape)
+- [x] High Priority: Complex business logic (enrichment, geo privacy, cutover)
+- [x] Benefits: Shared acceptance criteria across API, UI, and infra units; clearer UAT for cutover
+
+## Decision
+**Execute User Stories**: Yes
+
+**Reasoning**: Multiple personas and touchpoints; requirements span upload → enrichment → browse → admin. Stories will decompose full-cutover scope into testable slices and reduce ambiguity before Workflow Planning / Units Generation.
+
+## Expected Outcomes
+- Clear owner vs visitor story sets with acceptance criteria
+- Traceability from FR/NFR in `issue-103-requirements.md` to stories
+- Input for unit boundaries in Workflow Planning

--- a/aidlc-docs/inception/requirements/issue-103-clarification-questions.md
+++ b/aidlc-docs/inception/requirements/issue-103-clarification-questions.md
@@ -1,0 +1,72 @@
+# Issues #103 / #104 — Requirements Clarification Follow-ups
+
+I validated your answers. Two items need a clearer choice before I can write the requirements document.
+
+**Locked so far (no change needed):**
+
+
+| Q     | Decision                                                                            |
+| ----- | ----------------------------------------------------------------------------------- |
+| 1     | Full cutover this engagement                                                        |
+| 2     | Client/API fetch hybrid hosting                                                     |
+| 3     | Move public URLs to `/photos/<id>` + redirects from `/posts/<id>`                   |
+| 4     | Multi-upload with per-file title/caption/featured only                              |
+| 5     | Single `caption`/`description` field for detail + listings/RSS                      |
+| 6     | Auto-apply AI tags + editable via edit UI                                           |
+| 7     | AI enrichment = tags only (no auto title/caption)                                   |
+| 9     | Store precise GPS; round/fuzz for public map display                                |
+| 10    | Live API for listings/search; lightweight scheduled job for RSS/sitemap             |
+| 12    | Authenticated web edit UI for metadata                                              |
+| 13–15 | Skip Security / Resiliency / PBT extensions; **keep multi-region parity** as an NFR |
+
+
+---
+
+
+
+## Ambiguity 1 — Gallery management (from Q11)
+
+You chose **B** (move galleries to DynamoDB) and asked *“but how will we manage them?”*  
+Galleries today are markdown lists of photo ids under `content/galleries/`. We need a management model for the DB era.
+
+### Clarification Question 1
+
+How should galleries be created and edited after cutover?
+
+A) **Authenticated gallery admin UI** — Create/rename galleries and add/remove/reorder photo ids on the site (same auth pattern as photo edit / upload passcode)
+
+B) **CLI only** — e.g. `blog gallery:create`, `blog gallery:add`, `blog gallery:remove`; no web gallery admin in v1
+
+C) **Keep gallery definitions in markdown** — Only photo *metadata* moves to DynamoDB; `content/galleries/*/index.md` stays the source of gallery membership (simpler ops; contradicts pure “galleries in DynamoDB” but is a valid hybrid)
+
+D) **Same photo edit surface** — Minimal: galleries as named lists editable via API + a simple page under `/upload` or `/admin`; polish later
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+## Ambiguity 2 — Country / city tags (from Q8)
+
+You chose **B** (static map image when GPS present) and added: *“would like to also add country / city as tags.”*
+
+### Clarification Question 2
+
+How should country/city become tags?
+
+A) **Auto from reverse geocode** — When GPS exists, reverse-geocode (e.g. city + country) and merge those strings into `tags` automatically (alongside Bedrock AI tags)
+
+B) **Separate location fields + tags** — Store `city` / `country` (and optional place label) as dedicated metadata fields used for display; also add them to `tags` for filtering/search
+
+C) **Dedicated fields only** — Store `city` / `country` for display near the map; do **not** auto-add them to `tags` (author can add manually)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+When both answers are filled in, reply here and I will finalize `issue-103-requirements.md`.

--- a/aidlc-docs/inception/requirements/issue-103-requirement-verification-questions.md
+++ b/aidlc-docs/inception/requirements/issue-103-requirement-verification-questions.md
@@ -1,0 +1,271 @@
+# Issues #103 / #104 — Requirements Clarification Questions
+
+Please answer each question by filling in the letter after `[Answer]:` in this file.  
+If none of the options fit, choose the last option (**Other**) and describe your preference after the tag.
+
+**Engagement context (already captured):**
+
+- Migrate photo metadata from markdown in `content/posts/` to a database
+- Serve photos dynamically so publish does **not** require a full site rebuild
+- Keep blog + email posts on static markdown
+- Additional requirements (#104): multi-photo upload, title + description/caption, geo/map when present, automatic AI tags via upload API (Bedrock, like `blog photos:tag`)
+- Branch: `cursor/photo-metadata-dynamodb-be02`
+- Issues: [#103](https://github.com/micahwalter/micahwalter-www/issues/103), [#104](https://github.com/micahwalter/micahwalter-www/issues/104)
+
+---
+
+
+
+## Question 1 — Delivery scope for this engagement
+
+What should we deliver in this AI-DLC engagement?
+
+A) **Full cutover** — DynamoDB + read/write APIs, multi-upload UI, auto AI tags, GPS/map, migrate existing 43 photos, stop writing photo markdown, remove photo folders from content
+
+B) **Phased MVP first** — DynamoDB + APIs + process Lambda writes DB (dual-write with markdown still), multi-upload + caption fields, auto AI tags; map UI and markdown deletion in a follow-up
+
+C) **Backend foundation only** — DynamoDB schema, process Lambda → DB (dual-write), public read API, migration script; defer multi-upload UI, map, and frontend wiring to a follow-up
+
+D) **Design + spike only** — Requirements, architecture, and a thin spike (e.g. table + one read endpoint); implementation in a later engagement
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+## Question 2 — How photo pages are served (hosting model)
+
+Given `output: "export"` (no Next.js SSR in production), which approach should we target?
+
+A) **Client/API fetch (hybrid)** — Keep static site shells; homepage, `/photos`, and photo detail load metadata from `api.micahwalter.com` at runtime
+
+B) **Separate HTML origin** — CloudFront routes photo URLs to a Lambda/API that returns HTML from DynamoDB; blog pages stay on S3
+
+C) **Change hosting** — Move away from pure static export (ISR/SSR or dual-deploy) so Next can render photos dynamically
+
+D) **Decide in Application Design** — Lock functional requirements now; pick hosting option after design tradeoffs
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+## Question 3 — Public URL shape for photos
+
+A) **Keep** `/posts/<id>` — Numeric IDs stay under `/posts/`; blog posts keep title slugs
+
+B) **Move to** `/photos/<id>` — Cleaner split; add permanent redirects from `/posts/<id>` for existing photo URLs
+
+C) **Keep** `/posts/<id>` **for existing; new photos use** `/photos/<id>` — Mixed (generally avoid unless you have a reason)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B
+
+---
+
+
+
+## Question 4 — Multi-photo upload UX
+
+A) **Per-file fields only** — Each selected file has its own title, caption, featured toggle; no batch defaults
+
+B) **Batch defaults + per-file overrides** — Shared title/caption/featured defaults for the batch; can override per file before upload
+
+C) **Minimal batch** — Multi-file select with one shared title prefix / caption / featured; no per-file editing in v1 (edit after upload)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]:  A
+
+---
+
+
+
+## Question 5 — Caption vs excerpt
+
+A) **Separate fields** — `caption` (detail page body) and `excerpt` (cards/RSS/search); upload form edits caption; excerpt can default from caption
+
+B) **Single field** — One `description`/`caption` used for both detail and listings/RSS
+
+C) **Caption only for now** — Store caption; keep generating a short excerpt automatically from camera/AI until we need both
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B
+
+---
+
+
+
+## Question 6 — Automatic AI tagging behavior
+
+A) **Always auto-apply** — Process pipeline applies Bedrock tags immediately (like CLI `--auto-approve`); author can edit later
+
+B) **Auto-apply + editable** — Same as A, but v1 includes a simple authenticated edit path (or upload UI review step) to tweak tags before/after publish
+
+C) **Suggest only** — Generate tags but require explicit approve in upload UI before they are saved
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B
+
+---
+
+
+
+## Question 7 — AI enrichment beyond tags
+
+A) **Tags only** — Match today’s `blog photos:tag` (3–8 content tags)
+
+B) **Tags + suggested title** — If title empty/generic (e.g. IMG_1234), suggest a title; never overwrite an author-provided title
+
+C) **Tags + title + caption draft** — Also draft a short caption; author can edit
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: A
+
+---
+
+
+
+## Question 8 — Maps / geo display
+
+A) **Interactive map when GPS present** — e.g. MapLibre + OpenStreetMap (or similar); hide entirely when no coords
+
+B) **Static map image when GPS present** — Simpler (no JS map lib); link out to OpenStreetMap/Google
+
+C) **Text + coordinates only in v1** — Show location/lat-lon in EXIF panel; add map UI in a follow-up
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B, would like to also add country / city as tags
+
+---
+
+
+
+## Question 9 — GPS privacy
+
+A) **Publish exact coordinates** — Store and display full EXIF GPS
+
+B) **Round / fuzz for public display** — Store precise coords privately if needed, but display rounded (e.g. ~100–500m) on the public site
+
+C) **Opt-in per photo** — Default: no public map/coords; author can enable location display
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B
+
+---
+
+
+
+## Question 10 — Feeds, sitemap, and search after cutover
+
+A) **API-backed at build or on a schedule** — Prebuild scripts fetch photos from API when generating RSS/sitemap/`posts.json` (may lag until next site deploy or scheduled rebuild)
+
+B) **Dynamic where possible** — Search/listings hit the photo API live; keep RSS/sitemap updated via a lightweight scheduled job (not full site rebuild)
+
+C) **Accept lag for v1** — Photo pages/listings live immediately via API; RSS/sitemap/search update on next normal site deploy only
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B
+
+---
+
+
+
+## Question 11 — Galleries
+
+A) **Keep galleries as markdown** — `content/galleries/*/index.md` still lists photo ids; resolve photo metadata from the API/DB at build or runtime
+
+B) **Move galleries to DynamoDB too** — Same engagement if scope allows
+
+C) **Defer galleries** — Leave working as today until photos are migrated; fix breakage only if needed
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B, but how will we manage them?
+
+---
+
+
+
+## Question 12 — Post-upload editing
+
+A) **Authenticated edit UI on the site** — Update title, caption, tags, featured, location visibility without git
+
+B) **API + CLI only for v1** — `blog photos:update` (or similar); no web edit UI yet
+
+C) **Upload-time only for v1** — Set metadata at upload; changes require re-upload or manual DB/API later
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]:  A
+
+---
+
+
+
+## Question 13 — Security Baseline extension
+
+Should security extension rules be enforced for this project?
+
+A) Yes — enforce all SECURITY rules as blocking constraints (recommended for production-grade applications)
+
+B) No — skip all SECURITY rules (suitable for PoCs, prototypes, and experimental projects)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B
+
+---
+
+
+
+## Question 14 — Resiliency Baseline extension
+
+Should the resiliency baseline be applied to this project?
+
+**What this extension is.** Enabling it applies directional, design-time best practices from the AWS Well-Architected Framework (Reliability Pillar). It is a starting point, not a production certification.
+
+**What this extension is NOT.** It does not make the workload production-ready or guarantee availability/RTO/RPO.
+
+A) Yes — apply the resiliency baseline as directional best practices and design-time guidance
+
+B) No — skip the resiliency baseline
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: B, but maintain multi-region status on par with rest of the site
+
+---
+
+
+
+## Question 15 — Property-Based Testing extension
+
+Should property-based testing (PBT) rules be enforced for this project?
+
+A) Yes — enforce all PBT rules as blocking constraints
+
+B) Partial — enforce PBT rules only for pure functions and serialization round-trips
+
+C) No — skip all PBT rules (this repo has no test runner today; suitable if we keep validation lightweight)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: C
+
+---
+
+When all `[Answer]:` lines are filled in, reply here (e.g. “done”) and I will validate answers and produce the requirements document.

--- a/aidlc-docs/inception/requirements/issue-103-requirements.md
+++ b/aidlc-docs/inception/requirements/issue-103-requirements.md
@@ -1,0 +1,217 @@
+# Issues #103 / #104 — Requirements
+
+**Status**: Draft — pending approval  
+**Branch**: `cursor/photo-metadata-dynamodb-be02`  
+**Issues**: [#103](https://github.com/micahwalter/micahwalter-www/issues/103), [#104](https://github.com/micahwalter/micahwalter-www/issues/104)  
+**Date**: 2026-07-16
+
+---
+
+## Intent Analysis
+
+| Dimension | Assessment |
+|-----------|------------|
+| **User request** | Migrate photo metadata from YAML/markdown in `content/posts/` to a database; serve photos dynamically so publishes no longer require a full static deploy; add multi-upload, captions, geo/map, and automatic AI tags |
+| **Request type** | Migration + enhancement (brownfield) |
+| **Scope** | Cross-system — photo-upload Lambdas, new DynamoDB + APIs, Next.js photo UI, CloudFront redirects, CLI, galleries, feeds/search |
+| **Complexity** | Complex |
+| **Requirements depth** | Comprehensive |
+| **Out of scope** | Moving blog/email posts off markdown; changing image CDN binary layout (keep existing keys initially); Security / Resiliency / PBT AI-DLC extensions |
+
+---
+
+## Decisions Locked
+
+| Topic | Decision |
+|-------|----------|
+| Delivery scope | **Full cutover** this engagement |
+| Hosting model | **Client/API fetch hybrid** — static site shells; photo surfaces load metadata from `api.micahwalter.com` at runtime |
+| Public URLs | **`/photos/<id>`**; permanent redirects from legacy `/posts/<id>` for existing photo ids |
+| Multi-upload | Per-file title, caption, featured (no batch defaults) |
+| Caption model | **Single field** (`caption` / `description`) for detail page, cards, RSS, search |
+| AI tags | Auto-apply via Bedrock in process pipeline; **editable** via authenticated edit UI |
+| AI enrichment scope | **Tags only** (no auto title/caption) |
+| Maps | **Static map image** when public geo present; hide when absent |
+| Geo privacy | Store precise GPS; **round/fuzz** coordinates for public map display |
+| City/country | **Reverse-geocode** when GPS exists; merge city + country into `tags` (with AI tags) |
+| Feeds / search | Listings/search hit photo API live; **lightweight scheduled job** updates RSS/sitemap (not full site rebuild) |
+| Galleries | Move to DynamoDB; **authenticated gallery admin UI** |
+| Post-upload edit | Authenticated **web edit UI** (title, caption, tags, featured, location visibility as applicable) |
+| Multi-region | **Parity with rest of site** (primary + secondary patterns consistent with existing stacks) |
+| Extensions | Security Baseline **No**; Resiliency Baseline **No** (multi-region NFR still applies); PBT **No** |
+
+---
+
+## Functional Requirements
+
+### FR-1 — Photo metadata store
+
+1. Persist photo metadata in **DynamoDB** (not `content/posts/` markdown).
+2. Primary key: numeric ticket-allocated `id` (same counter as today via `api.micahwalter.com/tickets`).
+3. Attributes include at least: `title`, `caption`, `publishedAt`, `featured`, `tags[]`, EXIF fields (camera, lens, aperture, shutterSpeed, iso, focalLength, dateTaken), `latitude`/`longitude` (precise, internal), `publicLatitude`/`publicLongitude` (fuzzed) or equivalent derivation, `folderName` / image keys, `draft`, enrichment status timestamps.
+4. One-time migration imports all existing ~43 photo `index.md` records (and GPS from S3 originals where available).
+
+### FR-2 — Upload API & processing
+
+1. Extend `api.micahwalter.com/photos` so process Lambda **writes DynamoDB** and **does not commit** photo markdown to GitHub.
+2. Support **multi-file** upload from `/upload`: N parallel or batched presigned PUTs; each file is an independent photo record.
+3. Accept per-file **title**, **caption**, and **featured** at upload time.
+4. Extract EXIF including **GPS** when present.
+5. When GPS present: reverse-geocode to city/country and **merge into tags**; store precise coords; derive fuzzed public coords for map.
+6. Invoke **Bedrock Claude Vision** (same intent as `scripts/tag-photos.js`) to auto-apply 3–8 content tags; merge with author/geo tags; do not invent title/caption.
+7. Optimize and store images on existing images bucket/CDN (unchanged key strategy initially).
+8. Publish is complete when the DynamoDB record is writable/readable — **no site deploy required** for the photo to appear on API-backed surfaces.
+
+### FR-3 — Public read API
+
+1. Public (or cacheable) endpoints for: list photos (paginated), get photo by id, featured photo, and search/filter as needed by the frontend.
+2. Public responses expose **fuzzed** coordinates (or omit precise GPS); never require leaking full precision to anonymous clients if fuzzing is applied server-side.
+3. Authenticated write/update endpoints for photo metadata (used by edit UI and optionally CLI).
+
+### FR-4 — Frontend: browse & detail
+
+1. Homepage hero, Recent Photos, `/photos` grid, and photo detail load from the photo API (client-side or equivalent runtime fetch) — not from `getPhotos()` filesystem reads for production photo data.
+2. Photo detail URL: **`/photos/<id>`**.
+3. Detail page shows caption (single field), tags, EXIF, and a **static map image** when public geo exists; no map chrome when absent.
+4. Blog posts remain static markdown under `/posts/<slug>`.
+
+### FR-5 — URL migration
+
+1. Add permanent redirects (CloudFront function and/or static redirect pages) from `/posts/<photo-id>` → `/photos/<photo-id>` for all migrated photo ids.
+2. Update internal links (homepage, cards, galleries, search) to `/photos/<id>`.
+3. giscus / comments: pathname mapping must remain correct for the new photo URLs (or documented migration note).
+
+### FR-6 — Upload UI
+
+1. `/upload` supports multi-file selection.
+2. Per-file fields: title, caption, featured.
+3. Per-file upload progress/status.
+4. Passcode auth pattern retained (or evolved consistently with edit/gallery admin).
+
+### FR-7 — Authenticated edit UI
+
+1. Site owner can update title, caption, tags, featured (and location display-related fields as designed) without git.
+2. Same auth family as upload (passcode → short-lived token) unless Application Design chooses a shared admin session.
+
+### FR-8 — Galleries
+
+1. Gallery definitions (name/slug, ordered photo ids, metadata) live in DynamoDB.
+2. Authenticated **gallery admin UI** to create/rename galleries and add/remove/reorder photos.
+3. Public gallery pages resolve photo metadata from the photo API/DB.
+4. Migrate existing `content/galleries/*/index.md` into DynamoDB.
+
+### FR-9 — Feeds, sitemap, search
+
+1. In-site photo listings and search use the **live photo API**.
+2. RSS and sitemap (photo URLs) updated by a **lightweight scheduled job** (not a full Next.js site rebuild).
+3. Blog RSS/sitemap generation for markdown posts may remain in existing prebuild scripts.
+
+### FR-10 — CLI parity
+
+1. `blog photos:import` / tagging flows write to the API/DB (no photo markdown as source of truth).
+2. `blog photos:tag` may remain for re-runs/backfill against DB-backed photos.
+3. Gallery CLI optional; web admin is the required management path for v1.
+
+### FR-11 — Content tree cleanup
+
+1. After successful migration and cutover, remove photo folders from `content/posts/`.
+2. `content/posts/` retains blog and email markdown only.
+3. Remove or stop using GitHub-commit path in photo-upload process Lambda.
+
+---
+
+## Non-Functional Requirements
+
+### NFR-1 — Publish latency
+
+- A completed upload makes the photo visible on homepage / `/photos` / `/photos/<id>` **without** waiting for GitHub Actions site deploy.
+
+### NFR-2 — Static blog unchanged
+
+- Blog and email continue to use `output: "export"` and markdown; no requirement to SSR the whole site.
+
+### NFR-3 — Multi-region parity
+
+- Photo metadata store and APIs follow the site’s existing multi-region posture (primary us-east-1 with secondary patterns consistent with images/API stacks). Exact replication mechanism decided in Infrastructure Design.
+
+### NFR-4 — Security (baseline practices without Security extension)
+
+- Passcode + HMAC (or equivalent) for upload/edit/gallery admin.
+- Public read API does not expose precise GPS.
+- Secrets remain in Secrets Manager; no secrets in git.
+- Bedrock invoke limited to process/enrichment role.
+
+### NFR-5 — Image CDN
+
+- Existing CloudFront `/images/*` behavior and object layout remain valid; no mandatory re-key of historical objects in v1.
+
+### NFR-6 — Observability
+
+- Process/enrichment failures (EXIF, Bedrock, reverse-geocode, DynamoDB) are logged; partial success allowed (e.g. photo live without tags/map if enrichment fails) with retry/backfill path.
+
+### NFR-7 — Compatibility
+
+- Existing photo ids remain stable.
+- Legacy `/posts/<id>` photo URLs redirect permanently.
+
+---
+
+## User Scenarios (summary)
+
+1. **Owner uploads many photos** from phone/browser with per-file title/caption/featured → each appears live with AI tags (+ city/country tags if GPS) and optional static map.
+2. **Owner edits** a photo’s caption/tags/featured on the site without git or deploy.
+3. **Owner manages galleries** via admin UI (create, reorder membership).
+4. **Visitor** browses `/photos`, opens `/photos/<id>`, sees caption/tags/EXIF/map when available.
+5. **Visitor** hits old `/posts/<id>` photo link → lands on `/photos/<id>`.
+6. **Feeds** eventually include new photos via scheduled job without full site rebuild.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Uploading one or many photos does not create/update files under `content/posts/` for those photos.
+- [ ] New photos appear on API-backed UI without a full site rebuild.
+- [ ] `/upload` supports multi-file with per-file title, caption, featured + progress.
+- [ ] Process pipeline auto-applies Bedrock tags; edit UI can change tags/title/caption/featured.
+- [ ] When GPS exists: fuzzed static map on detail; city/country merged into tags; precise coords not exposed publicly.
+- [ ] When GPS absent: no map UI.
+- [ ] Public URLs are `/photos/<id>`; `/posts/<id>` redirects for former photo ids.
+- [ ] Galleries managed via authenticated admin UI and served from DynamoDB.
+- [ ] Existing ~43 photos migrated; photo markdown folders removable after cutover.
+- [ ] Live listings/search via API; RSS/sitemap photo updates via scheduled job.
+- [ ] Multi-region posture documented and implemented on par with peer stacks.
+
+---
+
+## Extension Configuration
+
+| Extension | Enabled | Notes |
+|-----------|---------|-------|
+| Security Baseline | No | Still apply practical auth/secrets/GPS privacy in NFRs |
+| Resiliency Baseline | No | Multi-region parity required as explicit NFR |
+| Property-Based Testing | No | No test runner in repo; lightweight validation as designed |
+
+---
+
+## Traceability
+
+| Source | Mapped requirements |
+|--------|---------------------|
+| Issue #103 | FR-1–5, FR-9–11, NFR-1–2, NFR-5, NFR-7 |
+| Issue #104 multi-upload | FR-2, FR-6 |
+| Issue #104 caption | FR-2, FR-4, FR-5 (single field), FR-7 |
+| Issue #104 geo/map | FR-2, FR-4, NFR-4 |
+| Issue #104 AI tags | FR-2, FR-7, NFR-6 |
+| Clarification gallery UI | FR-8 |
+| Clarification city/country tags | FR-2.5–2.6 |
+
+---
+
+## Open Items for Later Stages (not blocking requirements)
+
+- Exact DynamoDB schema, GSI design, and API shapes → Application / Infrastructure Design
+- Static map provider (e.g. static OSM/Mapbox URL pattern) → Functional / NFR Design
+- Fuzz radius (e.g. ~100–500m) → NFR Design
+- Reverse-geocode provider → Infrastructure Design
+- Dual-write period length during cutover → Workflow / Construction plan
+- Comment (giscus) pathname cutover checklist → Construction

--- a/aidlc-docs/inception/reverse-engineering/photo-subsystem.md
+++ b/aidlc-docs/inception/reverse-engineering/photo-subsystem.md
@@ -1,0 +1,145 @@
+# Photo Subsystem — Reverse Engineering Supplement
+
+**Analysis Date**: 2026-07-16T15:25:00Z  
+**Scope**: Photo content model, upload pipeline, AI tagging, display surfaces  
+**Related issues**: [#103](https://github.com/micahwalter/micahwalter-www/issues/103), [#104](https://github.com/micahwalter/micahwalter-www/issues/104), [#71](https://github.com/micahwalter/micahwalter-www/issues/71)  
+**Note**: Site-wide RE artifacts dated 2026-06-24 predate the photo-upload and ticket-server stacks. This supplement is the current source of truth for photo-related architecture.
+
+---
+
+## Business Context
+
+Photos are a first-class publishing type on micahwalter.com: capture → enrich → publish → browse. Today metadata lives in git markdown; binaries live on S3/CDN. Publishing a photo requires a full static site rebuild even though images are already on the CDN.
+
+### Business Transactions
+
+| Transaction | Actor | Current path |
+|-------------|-------|--------------|
+| Upload photo (web) | Site owner | `/upload` → API → S3 → process Lambda → GitHub commit `index.md` → deploy |
+| Import photo (CLI) | Site owner | `blog photos:import` → local markdown → `blog images:sync` → git push → deploy |
+| AI tag photo (CLI) | Site owner | `blog photos:tag` → Bedrock Claude Vision → update frontmatter tags |
+| Browse photos | Visitor | `/photos`, homepage hero/recent, `/posts/<id>` |
+| Feature on homepage | Site owner | `featured: true` in frontmatter; newest featured wins |
+
+---
+
+## Current Architecture
+
+```text
+  /upload form                         blog photos:import / photos:tag
+       |                                         |
+       v                                         v
+  api.micahwalter.com/photos              local content/posts/.../index.md
+  (auth, upload-url)                              |
+       |                                          |
+       v                                          v
+  S3 uploads bucket ----ObjectCreated----> process Lambda
+       |                                      |
+       |                         +------------+------------+
+       |                         |            |            |
+       |                         v            v            v
+       |                      EXIF       optimize      tickets API
+       |                    (no GPS)    -> images     (post_tickets)
+       |                         |         bucket          |
+       |                         +-----+------+------------+
+       |                               |
+       |                               v
+       |                        GitHub commit index.md
+       |                               |
+       |                               v
+       |                        Full site rebuild (deploy.yml)
+       |                               |
+       +-------------------------------v
+                    CloudFront www
+                    /posts/<id>  /photos  /  /images/*
+```
+
+### Text alternative
+
+1. Web upload authenticates, gets a presigned PUT URL, uploads bytes to the uploads bucket.
+2. Process Lambda extracts EXIF (camera/settings/date — **not GPS**), optimizes variants, allocates an `id` via tickets API, commits markdown to GitHub.
+3. Push to `main` triggers full Next.js static export + S3 sync + CloudFront invalidation.
+4. CLI import writes markdown locally; AI tagging is a separate Bedrock step; images sync to S3 independently.
+
+---
+
+## Content Model
+
+| Field | Source today | Notes |
+|-------|--------------|-------|
+| `type: photo` | Frontmatter | Discriminator in `lib/content.ts` |
+| `id` | Ticket server | Public URL slug: `/posts/<id>` |
+| `title` | Upload metadata or filename | Web form supports title |
+| `excerpt` | Auto (“Photo taken with …”) | Not a real caption |
+| `description` / `caption` | **Missing** | Proposed in #104 |
+| `featured` | Upload / frontmatter | Homepage hero eligibility |
+| `tags` | Default `photography`; AI via CLI | Not automatic on web upload |
+| `location` | Optional text | Rarely set; no map |
+| GPS lat/lon | **Not extracted** | `exif.js` omits GPS tags |
+| EXIF (camera, lens, …) | Process / import | Shown in `ExifDisplay` |
+| `folderName` | `YYYY-MM-DD-<slug>` | Image CDN key path |
+| `coverImage` | `./photo.jpeg` | Relative; UI resolves via folderName |
+
+**Counts (2026-07-16):** ~43 photo posts of ~157 total posts in `content/posts/`.
+
+---
+
+## Components & APIs
+
+| Piece | Path / name | Role |
+|-------|-------------|------|
+| Upload UI | `app/upload/UploadForm.tsx` | Single file; title + featured only |
+| Photo detail | `app/posts/[slug]` + `PhotoLayout` | Static HTML at build time |
+| Listings | `app/photos`, `app/page` | `getPhotos()` / `getFeaturedPhoto()` |
+| Content loader | `lib/content.ts` | Filesystem markdown |
+| Auth / init / process | `infra/photo-upload-lambdas/` | Stack `micahwalter-photo-upload` |
+| Tickets | `infra/tickets.yml`, `post_tickets` | Shared sequential IDs |
+| AI tags | `scripts/tag-photos.js` | Bedrock `us.anthropic.claude-sonnet-4-6` |
+| Images | `micahwalter-www-images` | Originals + 400/800/1200 WebP/JPEG |
+| Site hosting | S3 + CloudFront | `output: "export"` — no SSR |
+
+### Photo upload API (today)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/photos/auth` | Passcode → HMAC token |
+| POST | `/photos/upload-url` | Presigned PUT + metadata (title, featured) |
+| (S3 event) | process Lambda | EXIF, optimize, ticket, GitHub commit |
+
+**Gap:** No public read API for photo metadata. No DynamoDB photo table. No multi-file upload. No caption field. No GPS/map. No Bedrock in process Lambda.
+
+---
+
+## Pain Points (drive #103 / #104)
+
+1. **Publish latency** — metadata commit forces full static rebuild (~minutes) though images are already live.
+2. **Content clutter** — 43 photo folders in `content/posts/` for structured records.
+3. **Upload UX** — single file; no caption; no batch.
+4. **Enrichment split** — AI tags only via CLI; GPS unused; no map UI.
+5. **Static export constraint** — true dynamic Next routes need hybrid hosting or API-backed pages.
+
+---
+
+## Reusable Building Blocks for Migration
+
+- Numeric `id` as public slug (stable URLs)
+- Existing `/photos` write API + `api.micahwalter.com` domain
+- Ticket counter (`post_tickets`)
+- Image CDN layout (can keep `folderName` keys initially)
+- Proven Bedrock tagging prompt/logic in `scripts/tag-photos.js`
+- Newsletter DynamoDB patterns as reference for table/API design
+- CloudFront path behaviors already split `/images/*`
+
+---
+
+## Key Files Index
+
+| Area | Paths |
+|------|--------|
+| Content | `lib/content.ts`, `lib/galleries.ts`, `content/posts/*/index.md` |
+| UI | `app/upload/`, `app/photos/`, `app/posts/[slug]/`, `components/PhotoLayout.tsx`, `ExifDisplay.tsx`, `ResponsiveImage.tsx` |
+| Upload | `infra/photo-upload-lambdas/src/{auth,init,process}.js`, `lib/exif.js` |
+| AI | `scripts/tag-photos.js`, `cli/index.js` (`photos:tag`) |
+| Infra | `infra/photo-upload.yml`, `infra/tickets.yml`, `infra/infra.yml`, `infra/api-domain.yml` |
+| Deploy | `.github/workflows/deploy.yml`, `photo-upload-deploy.yml` |
+| Prior construction | `aidlc-docs/construction/issue-71-photo-upload-summary.md` |

--- a/aidlc-docs/inception/reverse-engineering/reverse-engineering-timestamp.md
+++ b/aidlc-docs/inception/reverse-engineering/reverse-engineering-timestamp.md
@@ -1,13 +1,14 @@
 # Reverse Engineering Metadata
 
-**Analysis Date**: 2026-06-24T00:02:00Z
-**Analyzer**: AI-DLC
-**Workspace**: /workspace
-**Git Branch**: main (up to date with origin/main)
-**Total Files Analyzed**: ~250 source files (TS/TSX/JS/Go/MDX excluding node_modules)
+**Analysis Date**: 2026-07-16T15:25:00Z  
+**Analyzer**: AI-DLC  
+**Workspace**: /workspace  
+**Git Branch**: `cursor/photo-metadata-dynamodb-be02`  
+**Engagement**: Issues #103 / #104 — Photo metadata DynamoDB + dynamic serving
 
-## Artifacts Generated
+## Artifacts
 
+### Site-wide (retained from 2026-06-24)
 - [x] business-overview.md
 - [x] architecture.md
 - [x] code-structure.md
@@ -17,33 +18,19 @@
 - [x] dependencies.md
 - [x] code-quality-assessment.md
 
-## Analysis Scope
+### Photo subsystem refresh (2026-07-16)
+- [x] photo-subsystem.md — **current source of truth for photo architecture**
 
-| Area | Files/Directories Scanned |
-|------|--------------------------|
-| App Router | `app/` (27 pages) |
-| Components | `components/` (21 files) |
-| Libraries | `lib/` (4 modules) |
-| Content | `content/posts/` (143 folders), galleries, sketches |
-| CLI/Scripts | `cli/`, `scripts/` |
-| Infrastructure | `infra/` (9 CloudFormation templates) |
-| Newsletter | `infra/newsletter-lambdas/` (7 Lambdas, 5 internal packages) |
-| CI/CD | `.github/workflows/` (3 workflows) |
-| Configuration | package.json, next.config.ts, tailwind.config.ts, tsconfig.json |
+## Staleness Notes
 
-## Key Findings Summary
+Site-wide artifacts from 2026-06-24 predate:
+- Photo upload stack (`micahwalter-photo-upload`, `/upload`)
+- Ticket server (`post_tickets`, `api.micahwalter.com/tickets`)
+- Homepage recent photos (#100)
+- Deploy optimizations (#90/#91)
 
-1. **Brownfield static site** — Next.js 15 with production static export, MDX CMS, 143 content posts
-2. **Dual subsystem architecture** — Static site (S3/CloudFront) + Newsletter API (Go Lambdas/DynamoDB/SES)
-3. **No automated tests** — ESLint only; no unit, integration, or E2E test suite
-4. **Multi-region failover** — us-east-1 primary, us-east-2 secondary for website and API
-5. **Mature tooling** — Unified `blog` CLI for content, images, and email operations
-6. **Well-documented** — CLAUDE.md and README.md provide strong existing architecture documentation
+For Issues #103/#104, use **photo-subsystem.md** plus construction summary `issue-71-photo-upload-summary.md`. Full site-wide re-analysis deferred; architecture.md still accurate for static site + newsletter core.
 
-## Staleness Tracking
-
-This analysis reflects the codebase state as of commit on `main` branch at analysis time (2026-06-24). Re-run reverse engineering if significant changes occur to:
-- App Router structure or lib/content.ts
-- Newsletter Lambda code or infra/newsletter.yml
-- CloudFormation templates or deployment workflows
-- Content schema (frontmatter fields, post types)
+## Related GitHub Issues
+- [#103](https://github.com/micahwalter/micahwalter-www/issues/103) — Proposal (DB metadata + dynamic routes)
+- [#104](https://github.com/micahwalter/micahwalter-www/issues/104) — Additional requirements (multi-upload, captions, geo/map, AI tags)

--- a/aidlc-docs/inception/user-stories/issue-103-personas.md
+++ b/aidlc-docs/inception/user-stories/issue-103-personas.md
@@ -1,0 +1,46 @@
+# Issues #103 / #104 — Personas
+
+**Branch**: `cursor/photo-metadata-dynamodb-be02`  
+**Plan**: Journey-based; Site Owner + Visitor
+
+---
+
+## P1 — Site Owner (Micah)
+
+| Attribute | Detail |
+|-----------|--------|
+| **Role** | Sole author/operator of micahwalter.com |
+| **Goals** | Publish photos quickly from phone or desktop; control titles/captions/tags/featured; organize galleries; avoid waiting on full site deploys |
+| **Pain today** | Each photo is a markdown commit + full rebuild; upload is single-file; AI tags require a separate CLI step; no caption field; no map |
+| **Environment** | Phone browser (`/upload`), laptop, occasional CLI (`blog photos:*`) |
+| **Auth** | Passcode → short-lived token for upload, edit, gallery admin |
+| **Success looks like** | Multi-upload with captions → photos live on site in seconds → tweak tags/featured in a web UI → manage galleries without git |
+
+**Primary journeys**: Publish a batch; Fix metadata; Build a gallery; Cut over from markdown
+
+---
+
+## P2 — Visitor
+
+| Attribute | Detail |
+|-----------|--------|
+| **Role** | Reader / photo viewer of the public site |
+| **Goals** | Browse recent and all photos; open a photo detail with caption, tags, EXIF; see where a photo was taken when location is shared; follow old links without dead ends |
+| **Pain today** | N/A (works, but owner latency and clutter are invisible); after migration, URL shape changes |
+| **Environment** | Mobile and desktop browsers; RSS/search occasionally |
+| **Auth** | None (public) |
+| **Success looks like** | Fast `/photos` and `/photos/<id>`; optional static map; old `/posts/<id>` photo links redirect cleanly; blog posts unchanged |
+
+**Primary journeys**: Visitor finds a photo (including legacy bookmark)
+
+---
+
+## Persona → journey map
+
+| Journey | Primary persona | Supporting |
+|---------|-----------------|------------|
+| Publish a batch | Site Owner | Visitor (sees result) |
+| Fix metadata | Site Owner | Visitor (sees updates) |
+| Visitor finds a photo | Visitor | — |
+| Build a gallery | Site Owner | Visitor |
+| Cut over from markdown | Site Owner | Visitor (redirects/feeds) |

--- a/aidlc-docs/inception/user-stories/issue-103-stories.md
+++ b/aidlc-docs/inception/user-stories/issue-103-stories.md
@@ -1,0 +1,262 @@
+# Issues #103 / #104 — User Stories
+
+**Organization**: Journey-based  
+**Granularity**: Small / vertical  
+**Acceptance criteria**: Checklist  
+**IDs**: `US-###` with FR/NFR mapping  
+**Personas**: [issue-103-personas.md](./issue-103-personas.md)  
+**Requirements**: [issue-103-requirements.md](../requirements/issue-103-requirements.md)
+
+---
+
+## Journey 1 — Publish a batch
+
+### US-001 — Multi-file upload with per-file metadata
+**Persona**: Site Owner  
+**Story**: As a Site Owner, I want to select multiple photos on `/upload` and set title, caption, and featured per file so I can publish a batch in one session.  
+**Maps**: FR-6, FR-2.2–2.3
+
+**Acceptance criteria**
+- [ ] `/upload` accepts multiple image files in one session
+- [ ] Each file has its own title, caption, and featured controls
+- [ ] Each file shows upload progress/status independently
+- [ ] Passcode auth still required before upload
+- [ ] JPEG/PNG constraints remain as today (unless explicitly extended later)
+
+---
+
+### US-002 — Upload persists to DynamoDB without a git commit
+**Persona**: Site Owner  
+**Story**: As a Site Owner, when my upload finishes processing, I want the photo metadata stored in the database (not committed as markdown) so publishing does not wait on a site deploy.  
+**Maps**: FR-1, FR-2.1, FR-2.8, NFR-1, FR-11.3
+
+**Acceptance criteria**
+- [ ] Process pipeline writes a photo record keyed by ticket `id`
+- [ ] No new `content/posts/.../index.md` is created for the upload
+- [ ] Process Lambda does not commit photo markdown to GitHub
+- [ ] Images still land on the existing images CDN paths
+- [ ] Photo is readable via the public photo API after processing succeeds
+
+---
+
+### US-003 — Auto AI tags on upload
+**Persona**: Site Owner  
+**Story**: As a Site Owner, I want Bedrock vision tags applied automatically when a photo is processed so I do not need a separate `blog photos:tag` step for every upload.  
+**Maps**: FR-2.6, NFR-6
+
+**Acceptance criteria**
+- [ ] Process/enrichment invokes Bedrock with the same tagging intent as `scripts/tag-photos.js` (3–8 content tags)
+- [ ] Tags are stored on the photo record and returned by the API
+- [ ] Author-provided tags (if any) are merged, not wiped
+- [ ] Title and caption are not overwritten by AI
+- [ ] If tagging fails, the photo still publishes; failure is logged and tags can be fixed later (US-006 / CLI backfill)
+
+---
+
+### US-004 — GPS enrichment, fuzzed public geo, city/country tags
+**Persona**: Site Owner  
+**Story**: As a Site Owner, when a photo has GPS EXIF, I want location enriched automatically (city/country tags + privacy-safe public coordinates) so visitors can see place context without exposing exact location.  
+**Maps**: FR-2.4–2.5, NFR-4
+
+**Acceptance criteria**
+- [ ] GPS is extracted from EXIF when present
+- [ ] Precise coordinates are stored internally
+- [ ] Public API exposes only fuzzed/rounded coordinates (or equivalent public fields)
+- [ ] Reverse geocode yields city and country that are merged into `tags`
+- [ ] Photos without GPS skip geo enrichment and do not fail the upload
+
+---
+
+## Journey 2 — Fix metadata
+
+### US-005 — Authenticated photo edit UI
+**Persona**: Site Owner  
+**Story**: As a Site Owner, I want to edit a photo’s title, caption, tags, and featured flag on the site so I can fix metadata without git or a redeploy.  
+**Maps**: FR-7, FR-3.3, US-003 follow-up
+
+**Acceptance criteria**
+- [ ] Authenticated edit surface can load an existing photo by id
+- [ ] Owner can update title, caption, tags, and featured
+- [ ] Changes persist to DynamoDB and appear on public API-backed pages without a site deploy
+- [ ] Unauthenticated users cannot modify photos
+- [ ] Auth uses the same passcode → token family as upload (or a documented shared admin session)
+
+---
+
+### US-006 — CLI can update or retag DB-backed photos
+**Persona**: Site Owner  
+**Story**: As a Site Owner, I want CLI import/tag flows to target the photo API/DB so desktop workflows stay useful after markdown is gone.  
+**Maps**: FR-10
+
+**Acceptance criteria**
+- [ ] `blog photos:import` (or successor) creates DB records rather than photo markdown as source of truth
+- [ ] `blog photos:tag` can retag an existing DB photo (backfill / retry)
+- [ ] CLI does not require committing photo `index.md` for new imports
+
+---
+
+## Journey 3 — Visitor finds a photo
+
+### US-007 — Browse photos from the live API
+**Persona**: Visitor  
+**Story**: As a Visitor, I want the homepage hero, recent photos, and `/photos` grid to show current photos from the API so new uploads appear without a site rebuild.  
+**Maps**: FR-3.1, FR-4.1, FR-9.1, NFR-1
+
+**Acceptance criteria**
+- [ ] Homepage featured photo is loaded from the photo API
+- [ ] Recent photos section uses API data (excluding hero as today)
+- [ ] `/photos` lists photos from the API with pagination comparable to today
+- [ ] Blog “Recent Posts” remains markdown/static and unaffected
+
+---
+
+### US-008 — Photo detail at `/photos/<id>`
+**Persona**: Visitor  
+**Story**: As a Visitor, I want to open a photo at `/photos/<id>` and see caption, tags, EXIF, and an optional static map so I can enjoy the photo with useful context.  
+**Maps**: FR-4.2–4.3, FR-5.2
+
+**Acceptance criteria**
+- [ ] Detail route is `/photos/<id>` (numeric id)
+- [ ] Page shows title, single caption field, tags, and EXIF when present
+- [ ] When public geo exists, a static map image is shown
+- [ ] When geo is absent, no map chrome/empty map is shown
+- [ ] Public page does not reveal precise GPS
+- [ ] Blog posts remain at `/posts/<slug>`
+
+---
+
+### US-009 — Legacy `/posts/<id>` photo URLs redirect
+**Persona**: Visitor  
+**Story**: As a Visitor with an old photo bookmark, I want `/posts/<photo-id>` to redirect to `/photos/<photo-id>` so my links keep working.  
+**Maps**: FR-5.1, NFR-7
+
+**Acceptance criteria**
+- [ ] For each migrated photo id, `/posts/<id>` returns a permanent redirect to `/photos/<id>`
+- [ ] Non-photo blog slugs under `/posts/` are unaffected
+- [ ] Internal site links use `/photos/<id>` for photos
+
+---
+
+### US-010 — In-site search includes live photos
+**Persona**: Visitor  
+**Story**: As a Visitor, I want site search to find photos by title/caption/tags from live API data so newly uploaded photos are discoverable.  
+**Maps**: FR-9.1
+
+**Acceptance criteria**
+- [ ] Search results can include DB-backed photos without waiting for a full site deploy
+- [ ] Photo results link to `/photos/<id>`
+- [ ] Blog post search continues to work for markdown posts
+
+---
+
+## Journey 4 — Build a gallery
+
+### US-011 — Gallery admin UI
+**Persona**: Site Owner  
+**Story**: As a Site Owner, I want an authenticated gallery admin UI to create galleries and add/remove/reorder photos so I can manage collections without markdown files.  
+**Maps**: FR-8.1–8.2
+
+**Acceptance criteria**
+- [ ] Owner can create and rename a gallery after auth
+- [ ] Owner can add/remove photo ids and reorder membership
+- [ ] Gallery definitions persist in DynamoDB
+- [ ] Unauthenticated users cannot modify galleries
+
+---
+
+### US-012 — Public galleries resolve DB photos
+**Persona**: Visitor  
+**Story**: As a Visitor, I want public gallery pages to show photos from the database so galleries stay correct after markdown cutover.  
+**Maps**: FR-8.3–8.4
+
+**Acceptance criteria**
+- [ ] Public gallery pages load membership from DynamoDB
+- [ ] Photo tiles/detail links use `/photos/<id>` and API metadata
+- [ ] Existing galleries are migrated from `content/galleries/*/index.md`
+
+---
+
+## Journey 5 — Cut over from markdown
+
+### US-013 — Migrate existing photos into DynamoDB
+**Persona**: Site Owner  
+**Story**: As a Site Owner, I want all existing photo markdown records migrated into DynamoDB (with GPS backfill where originals allow) so the site can run from one source of truth.  
+**Maps**: FR-1.4, FR-2.4
+
+**Acceptance criteria**
+- [ ] All existing ~43 photo posts are imported with stable ids
+- [ ] Core fields (title, featured, tags, EXIF, folder/image keys, publishedAt) are preserved
+- [ ] GPS is backfilled from S3 originals when EXIF GPS exists
+- [ ] Migration is idempotent or safely re-runnable for failed rows
+- [ ] Migrated photos are readable via the public API
+
+---
+
+### US-014 — Stop markdown photo source of truth and clean content tree
+**Persona**: Site Owner  
+**Story**: As a Site Owner, after cutover I want photo folders removed from `content/posts/` and processing to never write photo markdown so the content tree only holds blog/email.  
+**Maps**: FR-11, FR-2.1
+
+**Acceptance criteria**
+- [ ] Photo upload/process path does not write or commit photo markdown
+- [ ] Photo directories are removable from `content/posts/` after verification
+- [ ] Remaining `content/posts/` entries are blog and email only
+- [ ] Site blog/email builds still succeed
+
+---
+
+### US-015 — Scheduled RSS/sitemap updates for photos
+**Persona**: Visitor (consumer of feeds) / Site Owner (ops)  
+**Story**: As a feed consumer, I want photo URLs in RSS/sitemap refreshed by a lightweight scheduled job so feeds stay current without a full Next.js rebuild.  
+**Maps**: FR-9.2–9.3, NFR-1
+
+**Acceptance criteria**
+- [ ] A scheduled job updates photo entries in RSS and/or sitemap (as designed) from the photo API/DB
+- [ ] Job does not require a full static site rebuild
+- [ ] Blog markdown feed generation can remain on the existing prebuild path
+- [ ] New photo URLs in feeds use `/photos/<id>`
+
+---
+
+### US-016 — Multi-region parity for photo data plane
+**Persona**: Site Owner  
+**Story**: As a Site Owner, I want the photo metadata/API posture to match the site’s multi-region expectations so photos are as resilient as peer stacks.  
+**Maps**: NFR-3
+
+**Acceptance criteria**
+- [ ] Design/implementation documents primary + secondary posture consistent with existing API/images patterns
+- [ ] Failover or replication approach for photo metadata is implemented or explicitly staged with a tracked follow-up if infrastructure limits apply — default expectation is parity in this engagement
+
+---
+
+## Coverage matrix
+
+| Requirement | Stories |
+|-------------|---------|
+| FR-1 | US-002, US-013 |
+| FR-2 | US-001–004, US-014 |
+| FR-3 | US-002, US-005, US-007 |
+| FR-4 | US-007, US-008 |
+| FR-5 | US-008, US-009 |
+| FR-6 | US-001 |
+| FR-7 | US-005 |
+| FR-8 | US-011, US-012 |
+| FR-9 | US-007, US-010, US-015 |
+| FR-10 | US-006 |
+| FR-11 | US-002, US-014 |
+| NFR-1 | US-002, US-007, US-015 |
+| NFR-3 | US-016 |
+| NFR-4 | US-004, US-005, US-008 |
+| NFR-6 | US-003 |
+| NFR-7 | US-009, US-013 |
+
+---
+
+## INVEST notes
+
+- Stories are **Independent** enough to demo vertically once shared infra (table/API) exists; early stories may share foundation work called out in Workflow Planning units.
+- **Negotiable** implementation details (map provider, fuzz radius, exact admin routes) deferred to design stages.
+- Each story is **Valuable** to Owner or Visitor.
+- **Estimable** at unit-planning time; sizes kept small/vertical per plan.
+- **Small** relative to full cutover; cutover split into US-013–016.
+- **Testable** via checklist acceptance criteria above.

--- a/infra/photo-upload-lambdas/README.md
+++ b/infra/photo-upload-lambdas/README.md
@@ -1,36 +1,44 @@
 # Photo Upload Lambdas
 
-Backend for the web-based photo upload feature (`/upload`). Reproduces the
-`blog photos:import` + `blog images:sync` CLI pipeline as a serverless flow and
-commits the resulting post to the repo, which triggers the normal site deploy.
+Backend for the web-based photo upload feature (`/upload`) and the photo
+metadata API. Uploads are processed into the images CDN and **photo metadata is
+stored in DynamoDB** (`micahwalter-photos`). The process Lambda does **not**
+commit markdown to GitHub.
 
 ## Flow
 
 ```
 /upload (browser/phone)
-  → POST /photos/auth        passcode → short-lived signed token   (auth.handler)
-  → POST /photos/upload-url  token → presigned S3 PUT URL          (init.handler)
-  → PUT (direct to S3)       original photo → uploads/incoming/…
-                                   │ S3 ObjectCreated
-                                   ▼
-                             process.handler
-                               EXIF → resize 400/800/1200 WebP+JPEG
-                               → images bucket (processed + original)
-                               → commit index.mdx + post-counter via GitHub API
-                               → site rebuilds (~3–4 min)
+  → POST /photos/auth          passcode → short-lived signed token
+  → POST /photos/upload-url    token → presigned S3 PUT (title, caption, featured)
+  → PUT (direct to S3)         original → uploads/incoming/…
+                                     │ S3 ObjectCreated
+                                     ▼
+                               process.handler
+                                 EXIF → resize 400/800/1200 WebP+JPEG
+                                 → images bucket
+                                 → ticket id → DynamoDB (enrichmentStatus=pending)
+                                 → EventBridge PhotoPendingEnrichment (best-effort)
+                                 → (U2 enricher consumes later)
 ```
 
-Direct-to-S3 upload avoids API Gateway / Lambda request-size limits for
-multi-megabyte phone photos. Title and the "feature on homepage" flag ride
-along as S3 object metadata, so `process` needs no separate datastore.
+Public / owner HTTP:
 
-## Functions (one zip, three handlers)
+| Method | Path | Auth |
+|--------|------|------|
+| GET | `/photos` | none (list; `limit`, `cursor`) |
+| GET | `/photos/featured` | none |
+| GET | `/photos/{id}` | none |
+| PATCH | `/photos/{id}` | HMAC token (body `token` or `Authorization: Bearer`) |
 
-| Handler            | Route / trigger              | Purpose                              |
-|--------------------|------------------------------|--------------------------------------|
-| `src/auth.handler` | `POST /photos/auth`          | passcode → signed session token      |
-| `src/init.handler` | `POST /photos/upload-url`    | issue presigned S3 PUT URL           |
-| `src/process.handler` | S3 `uploads/incoming/*`   | process + commit the post            |
+## Functions (one zip)
+
+| Handler | Trigger | Purpose |
+|---------|---------|---------|
+| `src/auth.handler` | `POST /photos/auth` | passcode → session token |
+| `src/init.handler` | `POST /photos/upload-url` | presigned PUT + metadata |
+| `src/photos-api.handler` | GET/PATCH photo routes | DynamoDB read/write API |
+| `src/process.handler` | S3 `uploads/incoming/*` | optimize + DynamoDB + EventBridge |
 
 ## Secret
 
@@ -40,9 +48,17 @@ along as S3 object metadata, so `process` needs no separate datastore.
 {
   "passcode": "the upload passcode you enter on /upload",
   "hmac": "a long random string used to sign session tokens",
-  "githubToken": "fine-grained PAT, Contents: read & write on micahwalter/micahwalter-www"
+  "ticketsPasscode": "passcode for the ticket server API"
 }
 ```
+
+`githubToken` is no longer used by process (safe to remove from the secret when convenient).
+
+## Infra extras (U1)
+
+- DynamoDB table `micahwalter-photos` + GSI1 (`PHOTO` / `{publishedAt}#{id}`), PITR on
+- EventBridge bus `photo-bus` (enrichment handoff for U2)
+- SQS `photo-upload-process-dlq` (process async OnFailure)
 
 ## Build
 
@@ -50,6 +66,5 @@ along as S3 object metadata, so `process` needs no separate datastore.
 make build   # → dist/photo-upload.zip (bundles linux/arm64 sharp)
 ```
 
-Deploys automatically via `.github/workflows/photo-upload-deploy.yml` on push
-to `main`. See the repo `CLAUDE.md` (“Photo Upload”) for the full deploy and
-one-time setup steps.
+Deploys via `.github/workflows/photo-upload-deploy.yml` on push to `main` when
+paths under `infra/photo-upload*` change. See repo `CLAUDE.md` (“Photo Upload”).

--- a/infra/photo-upload-lambdas/package.json
+++ b/infra/photo-upload-lambdas/package.json
@@ -2,11 +2,14 @@
   "name": "photo-upload-lambdas",
   "version": "1.0.0",
   "private": true,
-  "description": "Lambda functions for web-based photo upload (auth, presign, process+commit)",
+  "description": "Lambda functions for web-based photo upload (auth, presign, process→DynamoDB, photos API)",
   "main": "src/process.js",
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.700.0",
+    "@aws-sdk/client-eventbridge": "^3.700.0",
     "@aws-sdk/client-s3": "^3.700.0",
     "@aws-sdk/client-secrets-manager": "^3.700.0",
+    "@aws-sdk/lib-dynamodb": "^3.700.0",
     "@aws-sdk/s3-request-presigner": "^3.700.0",
     "exifreader": "^4.36.1",
     "sharp": "^0.34.5"

--- a/infra/photo-upload-lambdas/src/init.js
+++ b/infra/photo-upload-lambdas/src/init.js
@@ -2,12 +2,8 @@
  * POST /photos/upload-url
  *
  * Validates the session token, then returns a presigned S3 PUT URL the browser
- * uses to upload the original photo directly to the uploads bucket. The chosen
- * title and the "feature on homepage" flag travel as object metadata so the
- * (decoupled) processing Lambda can read them when the S3 event fires.
- *
- * Direct-to-S3 upload sidesteps the API Gateway / Lambda request size limits,
- * which matters for multi-megabyte phone photos.
+ * uses to upload the original photo directly to the uploads bucket. Title,
+ * caption, and featured flag travel as object metadata for the process Lambda.
  */
 
 const crypto = require('crypto');
@@ -19,11 +15,8 @@ const { verify } = require('./lib/token');
 
 const s3 = new S3Client({});
 const UPLOADS_BUCKET = process.env.UPLOADS_BUCKET;
-const URL_TTL = 300; // presigned URL valid 5 minutes
+const URL_TTL = 300;
 
-// JPEG/PNG only for now. The default prebuilt sharp binary has no libheif, so
-// HEIC/HEIF is a documented follow-up. In practice iOS Safari transcodes HEIC
-// to JPEG when uploading through a file input, so this covers the phone case.
 const ALLOWED_TYPES = new Set(['image/jpeg', 'image/png']);
 
 function json(statusCode, body) {
@@ -43,7 +36,7 @@ exports.handler = async (event) => {
     return json(400, { message: 'Invalid request body' });
   }
 
-  const { token, filename, contentType, title, featured } = body;
+  const { token, filename, contentType, title, caption, featured } = body;
 
   const secret = await getSecret();
   if (!verify(secret.hmac, token)) {
@@ -56,9 +49,9 @@ exports.handler = async (event) => {
 
   const key = `uploads/incoming/${crypto.randomUUID()}/${safeName(filename)}`;
 
-  // Metadata must be ASCII; base64-encode the (possibly unicode) title.
   const metadata = {
     title: Buffer.from(String(title || ''), 'utf8').toString('base64'),
+    caption: Buffer.from(String(caption || ''), 'utf8').toString('base64'),
     featured: featured ? 'true' : 'false',
     'orig-filename': safeName(filename),
   };
@@ -72,21 +65,19 @@ exports.handler = async (event) => {
 
   const url = await getSignedUrl(s3, command, {
     expiresIn: URL_TTL,
-    // Metadata + Content-Type must be signed or S3 rejects the browser PUT
-    // with "headers present in the request which were not signed".
     unhoistableHeaders: new Set([
       'x-amz-meta-title',
+      'x-amz-meta-caption',
       'x-amz-meta-featured',
       'x-amz-meta-orig-filename',
     ]),
     signableHeaders: new Set(['content-type']),
   });
 
-  // The client must send exactly these headers on the PUT — they are part of
-  // the signature (SignedHeaders includes Content-Type and x-amz-meta-*).
   const headers = {
     'Content-Type': contentType,
     'x-amz-meta-title': metadata.title,
+    'x-amz-meta-caption': metadata.caption,
     'x-amz-meta-featured': metadata.featured,
     'x-amz-meta-orig-filename': metadata['orig-filename'],
   };

--- a/infra/photo-upload-lambdas/src/lib/photo-defaults.js
+++ b/infra/photo-upload-lambdas/src/lib/photo-defaults.js
@@ -1,0 +1,80 @@
+/**
+ * Title/caption defaults and GSI key helpers for photo records.
+ */
+
+const { titleFromFilename, todayDate } = require('./slug');
+
+function defaultTitle(titleMeta, origFilename) {
+  const t = (titleMeta || '').trim();
+  return t || titleFromFilename(origFilename || 'photo');
+}
+
+function defaultCaption(captionMeta, exif) {
+  const c = (captionMeta || '').trim();
+  if (c) return c;
+  if (exif && exif.camera) return `Photo taken with ${exif.camera}`;
+  return '';
+}
+
+function gsiKeys(publishedAt, id) {
+  return {
+    gsi1pk: 'PHOTO',
+    gsi1sk: `${publishedAt}#${id}`,
+  };
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+/**
+ * Build a new Photo item for DynamoDB (enrichmentStatus pending).
+ */
+function buildNewPhoto({
+  id,
+  title,
+  caption,
+  featured,
+  folderName,
+  coverImageKey,
+  originalKey,
+  exif,
+  draft = false,
+  tags = ['photography'],
+  category = 'Photography',
+}) {
+  const publishedAt = todayDate();
+  const ts = nowIso();
+  const idStr = String(id);
+  return {
+    id: idStr,
+    ...gsiKeys(publishedAt, idStr),
+    title,
+    caption,
+    publishedAt,
+    createdAt: ts,
+    updatedAt: ts,
+    featured: !!featured,
+    draft: !!draft,
+    tags: Array.isArray(tags) ? tags : ['photography'],
+    enrichmentStatus: 'pending',
+    folderName,
+    coverImageKey,
+    originalKey,
+    category,
+    exif: exif || {},
+    latitude: null,
+    longitude: null,
+    publicLatitude: null,
+    publicLongitude: null,
+  };
+}
+
+module.exports = {
+  defaultTitle,
+  defaultCaption,
+  gsiKeys,
+  nowIso,
+  buildNewPhoto,
+  todayDate,
+};

--- a/infra/photo-upload-lambdas/src/lib/photo-dto.js
+++ b/infra/photo-upload-lambdas/src/lib/photo-dto.js
@@ -1,0 +1,38 @@
+/**
+ * Map DynamoDB Photo → public DTO (never expose precise GPS).
+ */
+
+function toPublicPhoto(photo) {
+  if (!photo) return null;
+  const exif = photo.exif || {};
+  return {
+    id: photo.id,
+    title: photo.title,
+    caption: photo.caption || '',
+    publishedAt: photo.publishedAt,
+    createdAt: photo.createdAt,
+    updatedAt: photo.updatedAt,
+    featured: !!photo.featured,
+    tags: photo.tags || [],
+    enrichmentStatus: photo.enrichmentStatus,
+    folderName: photo.folderName,
+    coverImageKey: photo.coverImageKey,
+    category: photo.category || 'Photography',
+    exif: {
+      camera: exif.camera,
+      lens: exif.lens,
+      aperture: exif.aperture,
+      shutterSpeed: exif.shutterSpeed,
+      iso: exif.iso,
+      focalLength: exif.focalLength,
+      dateTaken: exif.dateTaken,
+      width: exif.width,
+      height: exif.height,
+      format: exif.format,
+    },
+    publicLatitude: photo.publicLatitude ?? null,
+    publicLongitude: photo.publicLongitude ?? null,
+  };
+}
+
+module.exports = { toPublicPhoto };

--- a/infra/photo-upload-lambdas/src/lib/photos-db.js
+++ b/infra/photo-upload-lambdas/src/lib/photos-db.js
@@ -1,0 +1,143 @@
+/**
+ * DynamoDB access for micahwalter-photos.
+ */
+
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+  UpdateCommand,
+  QueryCommand,
+} = require('@aws-sdk/lib-dynamodb');
+const { nowIso, gsiKeys } = require('./photo-defaults');
+
+const TABLE = process.env.PHOTOS_TABLE;
+const GSI1 = 'GSI1';
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
+  marshallOptions: { removeUndefinedValues: true },
+});
+
+function encodeCursor(key) {
+  if (!key) return null;
+  return Buffer.from(JSON.stringify(key), 'utf8').toString('base64url');
+}
+
+function decodeCursor(cursor) {
+  if (!cursor) return undefined;
+  try {
+    return JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+async function putPhoto(photo) {
+  await ddb.send(new PutCommand({
+    TableName: TABLE,
+    Item: photo,
+    ConditionExpression: 'attribute_not_exists(id)',
+  }));
+  return photo;
+}
+
+async function getPhoto(id) {
+  const res = await ddb.send(new GetCommand({
+    TableName: TABLE,
+    Key: { id: String(id) },
+  }));
+  return res.Item || null;
+}
+
+/**
+ * Partial update for owner PATCH. Rebuilds GSI keys if publishedAt changes (not allowed in U1).
+ */
+async function updatePhoto(id, patch) {
+  const allowed = ['title', 'caption', 'tags', 'featured', 'draft'];
+  const names = {};
+  const values = { ':u': nowIso() };
+  const parts = ['updatedAt = :u'];
+
+  for (const key of allowed) {
+    if (patch[key] === undefined) continue;
+    const nk = `#${key}`;
+    const vk = `:${key}`;
+    names[nk] = key;
+    values[vk] = patch[key];
+    parts.push(`${nk} = ${vk}`);
+  }
+
+  if (parts.length === 1) {
+    throw Object.assign(new Error('No updatable fields'), { statusCode: 400 });
+  }
+
+  const res = await ddb.send(new UpdateCommand({
+    TableName: TABLE,
+    Key: { id: String(id) },
+    UpdateExpression: `SET ${parts.join(', ')}`,
+    ExpressionAttributeNames: Object.keys(names).length ? names : undefined,
+    ExpressionAttributeValues: values,
+    ConditionExpression: 'attribute_exists(id)',
+    ReturnValues: 'ALL_NEW',
+  }));
+  return res.Attributes;
+}
+
+/**
+ * Newest-first public list (drafts excluded via FilterExpression).
+ */
+async function listPhotos({ limit = 12, cursor } = {}) {
+  const res = await ddb.send(new QueryCommand({
+    TableName: TABLE,
+    IndexName: GSI1,
+    KeyConditionExpression: 'gsi1pk = :pk',
+    ExpressionAttributeValues: {
+      ':pk': 'PHOTO',
+      ':false': false,
+    },
+    FilterExpression: 'draft = :false',
+    ScanIndexForward: false,
+    Limit: Math.min(Math.max(Number(limit) || 12, 1), 50),
+    ExclusiveStartKey: decodeCursor(cursor),
+  }));
+
+  return {
+    items: res.Items || [],
+    cursor: encodeCursor(res.LastEvaluatedKey),
+  };
+}
+
+/**
+ * Newest featured non-draft, else newest non-draft overall.
+ */
+async function getFeaturedPhoto() {
+  // Pull a window of newest public photos and pick featured, else first.
+  const res = await ddb.send(new QueryCommand({
+    TableName: TABLE,
+    IndexName: GSI1,
+    KeyConditionExpression: 'gsi1pk = :pk',
+    ExpressionAttributeValues: {
+      ':pk': 'PHOTO',
+      ':false': false,
+    },
+    FilterExpression: 'draft = :false',
+    ScanIndexForward: false,
+    Limit: 50,
+  }));
+
+  const items = res.Items || [];
+  if (items.length === 0) return null;
+  return items.find((p) => p.featured === true) || items[0];
+}
+
+module.exports = {
+  putPhoto,
+  getPhoto,
+  updatePhoto,
+  listPhotos,
+  getFeaturedPhoto,
+  encodeCursor,
+  decodeCursor,
+  gsiKeys,
+};

--- a/infra/photo-upload-lambdas/src/photos-api.js
+++ b/infra/photo-upload-lambdas/src/photos-api.js
@@ -1,0 +1,110 @@
+/**
+ * HTTP API for photos — GET list/featured/{id}, PATCH {id}.
+ * Routed by API Gateway routeKey on a single Lambda.
+ */
+
+const { getSecret } = require('./lib/secrets');
+const { verify } = require('./lib/token');
+const {
+  getPhoto,
+  updatePhoto,
+  listPhotos,
+  getFeaturedPhoto,
+} = require('./lib/photos-db');
+const { toPublicPhoto } = require('./lib/photo-dto');
+
+function json(statusCode, body) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+function extractToken(event, body) {
+  const auth = event.headers?.authorization || event.headers?.Authorization || '';
+  if (auth.toLowerCase().startsWith('bearer ')) {
+    return auth.slice(7).trim();
+  }
+  return body?.token;
+}
+
+exports.handler = async (event) => {
+  const routeKey = event.routeKey || '';
+
+  try {
+    if (routeKey === 'GET /photos') {
+      const qs = event.queryStringParameters || {};
+      const limit = qs.limit;
+      const cursor = qs.cursor;
+      const page = await listPhotos({ limit, cursor });
+      return json(200, {
+        items: page.items.map(toPublicPhoto),
+        cursor: page.cursor,
+        limit: Math.min(Math.max(Number(limit) || 12, 1), 50),
+      });
+    }
+
+    if (routeKey === 'GET /photos/featured') {
+      const photo = await getFeaturedPhoto();
+      if (!photo) return json(404, { message: 'No photos' });
+      return json(200, toPublicPhoto(photo));
+    }
+
+    if (routeKey === 'GET /photos/{id}') {
+      const id = event.pathParameters?.id;
+      if (!id) return json(400, { message: 'Missing id' });
+      const photo = await getPhoto(id);
+      if (!photo || photo.draft) return json(404, { message: 'Not found' });
+      return json(200, toPublicPhoto(photo));
+    }
+
+    if (routeKey === 'PATCH /photos/{id}') {
+      const id = event.pathParameters?.id;
+      if (!id) return json(400, { message: 'Missing id' });
+
+      let body = {};
+      try {
+        body = JSON.parse(event.body || '{}');
+      } catch {
+        return json(400, { message: 'Invalid request body' });
+      }
+
+      const secret = await getSecret();
+      const token = extractToken(event, body);
+      if (!verify(secret.hmac, token)) {
+        return json(401, { message: 'Session expired or invalid' });
+      }
+
+      const patch = {};
+      if (body.title !== undefined) {
+        const t = String(body.title).trim();
+        if (!t) return json(400, { message: 'title cannot be empty' });
+        patch.title = t;
+      }
+      if (body.caption !== undefined) patch.caption = String(body.caption);
+      if (body.tags !== undefined) {
+        if (!Array.isArray(body.tags)) return json(400, { message: 'tags must be an array' });
+        patch.tags = body.tags.map(String);
+      }
+      if (body.featured !== undefined) patch.featured = !!body.featured;
+      if (body.draft !== undefined) patch.draft = !!body.draft;
+
+      try {
+        const updated = await updatePhoto(id, patch);
+        return json(200, toPublicPhoto(updated));
+      } catch (err) {
+        if (err.name === 'ConditionalCheckFailedException') {
+          return json(404, { message: 'Not found' });
+        }
+        if (err.statusCode === 400) return json(400, { message: err.message });
+        throw err;
+      }
+    }
+
+    return json(404, { message: `Unknown route: ${routeKey}` });
+  } catch (err) {
+    console.error(err);
+    return json(500, { message: 'Internal error' });
+  }
+};

--- a/infra/photo-upload-lambdas/src/process.js
+++ b/infra/photo-upload-lambdas/src/process.js
@@ -1,17 +1,9 @@
 /**
  * S3 ObjectCreated trigger on uploads/incoming/*
  *
- * The end-to-end worker: it takes a freshly-uploaded original and reproduces
- * the entire CLI pipeline (EXIF extraction → resize → S3 upload → MDX post),
- * then commits the post to the repo, which triggers the normal site deploy.
- *
- *   1. download the original from the uploads bucket
- *   2. extract EXIF + dimensions
- *   3. generate 400/800/1200 WebP+JPEG and upload to the images bucket
- *   4. upload the original to images/originals/...
- *   5. allocate post id via ticket server API
- *   6. commit index.md in one commit
- *   7. delete the incoming object
+ * Downloads the original, extracts EXIF, optimizes variants to the images
+ * bucket, allocates a ticket id, writes DynamoDB (no GitHub commit), and
+ * emits a best-effort EventBridge enrichment event for U2.
  */
 
 const path = require('path');
@@ -21,24 +13,48 @@ const {
   PutObjectCommand,
   DeleteObjectCommand,
 } = require('@aws-sdk/client-s3');
+const { EventBridgeClient, PutEventsCommand } = require('@aws-sdk/client-eventbridge');
 
 const { getSecret } = require('./lib/secrets');
 const { extractExif } = require('./lib/exif');
 const { optimize } = require('./lib/optimize');
-const { generateSlug, titleFromFilename, todayDate, buildFrontmatter } = require('./lib/slug');
-const { commitFiles } = require('./lib/github');
+const { generateSlug } = require('./lib/slug');
 const { allocatePostId } = require('./lib/tickets');
+const {
+  defaultTitle,
+  defaultCaption,
+  buildNewPhoto,
+  todayDate,
+} = require('./lib/photo-defaults');
+const { putPhoto } = require('./lib/photos-db');
 
 const s3 = new S3Client({});
+const events = new EventBridgeClient({});
 
 const IMAGES_BUCKET = process.env.IMAGES_BUCKET;
-const GITHUB_REPO = process.env.GITHUB_REPO;       // "owner/name"
-const GITHUB_BRANCH = process.env.GITHUB_BRANCH || 'main';
+const EVENT_BUS_NAME = process.env.PHOTO_EVENT_BUS || 'photo-bus';
 const CACHE_CONTROL = 'public, max-age=31536000, immutable';
 
 async function streamToBuffer(stream) {
   const bytes = await stream.transformToByteArray();
   return Buffer.from(bytes);
+}
+
+async function emitEnrichmentEvent(photoId) {
+  try {
+    await events.send(new PutEventsCommand({
+      Entries: [
+        {
+          EventBusName: EVENT_BUS_NAME,
+          Source: 'micahwalter.photos',
+          DetailType: 'PhotoPendingEnrichment',
+          Detail: JSON.stringify({ photoId: String(photoId) }),
+        },
+      ],
+    }));
+  } catch (err) {
+    console.error(`Enrichment PutEvents failed for ${photoId}:`, err.message);
+  }
 }
 
 async function processObject(bucket, key) {
@@ -52,22 +68,28 @@ async function processObject(bucket, key) {
   const titleMeta = metadata.title
     ? Buffer.from(metadata.title, 'base64').toString('utf8').trim()
     : '';
+  const captionMeta = metadata.caption
+    ? Buffer.from(metadata.caption, 'base64').toString('utf8')
+    : '';
   const featured = metadata.featured === 'true';
 
   const ext = (path.extname(origFilename) || '.jpg').toLowerCase();
   const photoFilename = `photo${ext}`;
 
-  // Derive folder + slug exactly like the CLI: YYYY-MM-DD-<slug-from-filename>.
   const date = todayDate();
   const slug = generateSlug(origFilename);
   const folder = `${date}-${slug}`;
 
-  // 2. EXIF + dimensions
   const exif = await extractExif(buffer);
 
-  // 3 + 4. resize and upload everything (processed variants + original) in
-  // parallel — they are independent, so there's no reason to serialize them.
-  const variants = await optimize(buffer, 'photo');
+  let variants;
+  try {
+    variants = await optimize(buffer, 'photo');
+  } catch (err) {
+    console.error('Optimize failed — no DynamoDB write:', err.message);
+    throw err;
+  }
+
   await Promise.all([
     ...variants.map((v) =>
       s3.send(new PutObjectCommand({
@@ -87,50 +109,38 @@ async function processObject(bucket, key) {
     })),
   ]);
 
-  // 5 + 6. Allocate post id from ticket server, then commit the post. Retry on
-  // GitHub ref conflicts (two near-simultaneous uploads).
   const secret = await getSecret();
-  const token = secret.githubToken;
   if (!secret.ticketsPasscode) {
     throw new Error('photo-upload-secrets missing ticketsPasscode');
   }
-  const title = titleMeta || titleFromFilename(origFilename);
-  const excerpt = exif.camera ? `Photo taken with ${exif.camera}` : 'A new photo';
 
-  const MAX_ATTEMPTS = 4;
-  let committed;
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    const id = await allocatePostId(secret.ticketsPasscode);
-
-    const indexMd = buildFrontmatter({
-      id, title, date, excerpt,
-      category: 'Photography',
-      tags: ['photography'],
-      photoFilename, featured, exif,
-    });
-
-    try {
-      const commitSha = await commitFiles({
-        token,
-        repo: GITHUB_REPO,
-        branch: GITHUB_BRANCH,
-        message: `Add photo post: ${title} (#${id})${featured ? ' [featured]' : ''}`,
-        files: [
-          { path: `content/posts/${folder}/index.md`, content: indexMd },
-        ],
-      });
-      committed = { commitSha, id };
-      break;
-    } catch (err) {
-      if (attempt === MAX_ATTEMPTS) throw err;
-      const delay = 250 * 2 ** (attempt - 1);
-      console.warn(`Commit attempt ${attempt} failed (${err.message}); retrying in ${delay}ms`);
-      await new Promise((r) => setTimeout(r, delay));
-    }
+  let id;
+  try {
+    id = await allocatePostId(secret.ticketsPasscode);
+  } catch (err) {
+    console.error('Ticket allocation failed — no DynamoDB write:', err.message);
+    throw err;
   }
-  console.log(`Committed ${committed.commitSha} — post id ${committed.id}, folder ${folder}`);
 
-  // 7. clean up the incoming original
+  const title = defaultTitle(titleMeta, origFilename);
+  const caption = defaultCaption(captionMeta, exif);
+
+  const photo = buildNewPhoto({
+    id,
+    title,
+    caption,
+    featured,
+    folderName: folder,
+    coverImageKey: `images/posts/${folder}/${photoFilename}`,
+    originalKey: `images/originals/posts/${folder}/${photoFilename}`,
+    exif,
+  });
+
+  await putPhoto(photo);
+  console.log(`Wrote photo id ${id} folder ${folder} (enrichment pending)`);
+
+  await emitEnrichmentEvent(id);
+
   await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
 }
 

--- a/infra/photo-upload.yml
+++ b/infra/photo-upload.yml
@@ -1,13 +1,11 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >
   Web-based photo upload — uploads S3 bucket, Secrets Manager secret, API
-  Gateway (HTTP) with auth + presign routes, and a processing Lambda that
-  resizes, extracts EXIF, and commits the post to the repo via the GitHub API.
+  Gateway (HTTP) with auth, presign, and photos CRUD routes, DynamoDB photo
+  metadata, EventBridge enrichment bus, and a processing Lambda that resizes,
+  extracts EXIF, and writes DynamoDB (no GitHub markdown commit).
   Reuses the newsletter artifacts bucket for Lambda zips.
 
-# ---------------------------------------------------------------------------
-# Parameters
-# ---------------------------------------------------------------------------
 Parameters:
 
   LambdaArtifactsBucket:
@@ -40,24 +38,13 @@ Parameters:
     Default: micahwalter-www-images
     Description: Existing images bucket where processed images + originals are written
 
-  GitHubRepo:
+  PhotosTableName:
     Type: String
-    Default: micahwalter/micahwalter-www
-    Description: owner/name of the repo the processing Lambda commits to
+    Default: micahwalter-photos
+    Description: DynamoDB table for photo metadata
 
-  GitHubBranch:
-    Type: String
-    Default: main
-    Description: Branch the processing Lambda commits to (push triggers deploy)
-
-# ---------------------------------------------------------------------------
-# Resources
-# ---------------------------------------------------------------------------
 Resources:
 
-  # -------------------------------------------------------------------------
-  # Uploads bucket — receives presigned PUTs, auto-expires incoming objects
-  # -------------------------------------------------------------------------
   UploadsBucket:
     Type: AWS::S3::Bucket
     DependsOn: ProcessFnPermission
@@ -99,23 +86,55 @@ Resources:
         - { Key: Project, Value: micahwalter-photo-upload }
         - { Key: ManagedBy, Value: CloudFormation }
 
-  # -------------------------------------------------------------------------
-  # Secret — passcode, token HMAC key, GitHub token
-  # -------------------------------------------------------------------------
   PhotoUploadSecret:
     Type: AWS::SecretsManager::Secret
     Properties:
       Name: photo-upload-secrets
       Description: >
         Photo upload secrets. Populate manually after first deploy:
-        {"passcode":"<upload passcode>","hmac":"<random signing key>","githubToken":"<fine-grained PAT, contents:write>","ticketsPasscode":"<ticket server passcode>"}
+        {"passcode":"<upload passcode>","hmac":"<random signing key>","ticketsPasscode":"<ticket server passcode>"}
+        (githubToken no longer used by process Lambda)
       Tags:
         - { Key: Project, Value: micahwalter-photo-upload }
         - { Key: ManagedBy, Value: CloudFormation }
 
-  # -------------------------------------------------------------------------
-  # API Gateway — HTTP API with CORS
-  # -------------------------------------------------------------------------
+  PhotosTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Ref PhotosTableName
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - { AttributeName: id, AttributeType: S }
+        - { AttributeName: gsi1pk, AttributeType: S }
+        - { AttributeName: gsi1sk, AttributeType: S }
+      KeySchema:
+        - { AttributeName: id, KeyType: HASH }
+      GlobalSecondaryIndexes:
+        - IndexName: GSI1
+          KeySchema:
+            - { AttributeName: gsi1pk, KeyType: HASH }
+            - { AttributeName: gsi1sk, KeyType: RANGE }
+          Projection: { ProjectionType: ALL }
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      Tags:
+        - { Key: Project, Value: micahwalter-photo-upload }
+        - { Key: ManagedBy, Value: CloudFormation }
+
+  PhotoEventBus:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: photo-bus
+
+  ProcessDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: photo-upload-process-dlq
+      MessageRetentionPeriod: 1209600
+      Tags:
+        - { Key: Project, Value: micahwalter-photo-upload }
+        - { Key: ManagedBy, Value: CloudFormation }
+
   PhotoApi:
     Type: AWS::ApiGatewayV2::Api
     Properties:
@@ -125,8 +144,8 @@ Resources:
         AllowOrigins:
           - !Ref SiteUrl
           - http://localhost:3000
-        AllowMethods: [POST, OPTIONS]
-        AllowHeaders: [Content-Type]
+        AllowMethods: [GET, POST, PATCH, OPTIONS]
+        AllowHeaders: [Content-Type, Authorization]
         MaxAge: 300
       Tags:
         Project: micahwalter-photo-upload
@@ -137,12 +156,14 @@ Resources:
     DependsOn:
       - AuthRoute
       - InitRoute
+      - PhotosListRoute
+      - PhotosFeaturedRoute
+      - PhotosGetRoute
+      - PhotosPatchRoute
     Properties:
       ApiId: !Ref PhotoApi
       StageName: $default
       AutoDeploy: true
-      # Cap request rates to blunt passcode brute-forcing and abuse. /auth is
-      # throttled hardest since it is the only unauthenticated route.
       DefaultRouteSettings:
         ThrottlingBurstLimit: 10
         ThrottlingRateLimit: 5
@@ -159,9 +180,6 @@ Resources:
       Stage: !Ref PhotoApiStage
       ApiMappingKey: photos
 
-  # -------------------------------------------------------------------------
-  # IAM roles
-  # -------------------------------------------------------------------------
   AuthFnRole:
     Type: AWS::IAM::Role
     Properties:
@@ -203,8 +221,6 @@ Resources:
               - Effect: Allow
                 Action: secretsmanager:GetSecretValue
                 Resource: !Ref PhotoUploadSecret
-              # Presigned PUT URLs are signed with this role's credentials, so
-              # the role must be allowed to PutObject into the uploads bucket.
               - Effect: Allow
                 Action: s3:PutObject
                 Resource: !Sub arn:aws:s3:::${UploadsBucketName}/uploads/incoming/*
@@ -235,10 +251,51 @@ Resources:
               - Effect: Allow
                 Action: secretsmanager:GetSecretValue
                 Resource: !Ref PhotoUploadSecret
+              - Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                  - dynamodb:GetItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                Resource:
+                  - !GetAtt PhotosTable.Arn
+                  - !Sub ${PhotosTable.Arn}/index/*
+              - Effect: Allow
+                Action: events:PutEvents
+                Resource: !GetAtt PhotoEventBus.Arn
+              - Effect: Allow
+                Action: sqs:SendMessage
+                Resource: !GetAtt ProcessDlq.Arn
 
-  # -------------------------------------------------------------------------
-  # Lambda functions — one zip, three handlers
-  # -------------------------------------------------------------------------
+  PhotosApiFnRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: photo-upload-photos-api-fn-role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: { Service: lambda.amazonaws.com }
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: PhotosApiFnPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource: !Ref PhotoUploadSecret
+              - Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                Resource:
+                  - !GetAtt PhotosTable.Arn
+                  - !Sub ${PhotosTable.Arn}/index/*
+
   AuthFn:
     Type: AWS::Lambda::Function
     Properties:
@@ -292,13 +349,38 @@ Resources:
         Variables:
           SECRET_ARN: !Ref PhotoUploadSecret
           IMAGES_BUCKET: !Ref ImagesBucketName
-          GITHUB_REPO: !Ref GitHubRepo
-          GITHUB_BRANCH: !Ref GitHubBranch
+          PHOTOS_TABLE: !Ref PhotosTable
+          PHOTO_EVENT_BUS: !Ref PhotoEventBus
           TICKETS_API_URL: https://api.micahwalter.com/tickets
 
-  # -------------------------------------------------------------------------
-  # API integrations, routes, and invoke permissions
-  # -------------------------------------------------------------------------
+  ProcessFnEventInvokeConfig:
+    Type: AWS::Lambda::EventInvokeConfig
+    Properties:
+      FunctionName: !Ref ProcessFn
+      Qualifier: $LATEST
+      MaximumRetryAttempts: 2
+      DestinationConfig:
+        OnFailure:
+          Destination: !GetAtt ProcessDlq.Arn
+
+  PhotosApiFn:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: photo-upload-photos-api
+      Runtime: nodejs20.x
+      Architectures: [arm64]
+      Handler: src/photos-api.handler
+      Role: !GetAtt PhotosApiFnRole.Arn
+      Code:
+        S3Bucket: !Ref LambdaArtifactsBucket
+        S3Key: !Sub ${LambdaArtifactsKeyPrefix}/photo-upload.zip
+      Timeout: 10
+      MemorySize: 256
+      Environment:
+        Variables:
+          SECRET_ARN: !Ref PhotoUploadSecret
+          PHOTOS_TABLE: !Ref PhotosTable
+
   AuthIntegration:
     Type: AWS::ApiGatewayV2::Integration
     Properties:
@@ -315,6 +397,14 @@ Resources:
       IntegrationUri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${InitFn.Arn}/invocations
       PayloadFormatVersion: '2.0'
 
+  PhotosApiIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref PhotoApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PhotosApiFn.Arn}/invocations
+      PayloadFormatVersion: '2.0'
+
   AuthRoute:
     Type: AWS::ApiGatewayV2::Route
     Properties:
@@ -328,6 +418,34 @@ Resources:
       ApiId: !Ref PhotoApi
       RouteKey: POST /upload-url
       Target: !Sub integrations/${InitIntegration}
+
+  PhotosListRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref PhotoApi
+      RouteKey: GET /photos
+      Target: !Sub integrations/${PhotosApiIntegration}
+
+  PhotosFeaturedRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref PhotoApi
+      RouteKey: GET /photos/featured
+      Target: !Sub integrations/${PhotosApiIntegration}
+
+  PhotosGetRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref PhotoApi
+      RouteKey: GET /photos/{id}
+      Target: !Sub integrations/${PhotosApiIntegration}
+
+  PhotosPatchRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref PhotoApi
+      RouteKey: PATCH /photos/{id}
+      Target: !Sub integrations/${PhotosApiIntegration}
 
   AuthFnPermission:
     Type: AWS::Lambda::Permission
@@ -345,8 +463,14 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PhotoApi}/*/*/upload-url
 
-  # Allow S3 (the uploads bucket) to invoke the processing Lambda. Uses a
-  # literal SourceArn to break the circular dependency with the bucket.
+  PhotosApiFnPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref PhotosApiFn
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PhotoApi}/*/*/*
+
   ProcessFnPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -356,9 +480,6 @@ Resources:
       SourceAccount: !Ref AWS::AccountId
       SourceArn: !Sub arn:aws:s3:::${UploadsBucketName}
 
-  # -------------------------------------------------------------------------
-  # Alarms
-  # -------------------------------------------------------------------------
   ProcessFnErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -376,9 +497,6 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
-# ---------------------------------------------------------------------------
-# Outputs
-# ---------------------------------------------------------------------------
 Outputs:
 
   ApiEndpoint:
@@ -389,6 +507,18 @@ Outputs:
     Description: Bucket that receives browser uploads
     Value: !Ref UploadsBucket
 
+  PhotosTableName:
+    Description: DynamoDB table for photo metadata
+    Value: !Ref PhotosTable
+
+  PhotoEventBusName:
+    Description: EventBridge bus for PhotoPendingEnrichment (U2 consumer)
+    Value: !Ref PhotoEventBus
+
+  ProcessDlqUrl:
+    Description: DLQ for process Lambda async failures
+    Value: !Ref ProcessDlq
+
   SecretArn:
-    Description: Secrets Manager ARN — set passcode / hmac / githubToken after first deploy
+    Description: Secrets Manager ARN — set passcode / hmac / ticketsPasscode after first deploy
     Value: !Ref PhotoUploadSecret


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **U1 (photo data plane)** for [#103](https://github.com/micahwalter/micahwalter-www/issues/103) / [#104](https://github.com/micahwalter/micahwalter-www/issues/104): move photo metadata from markdown under `content/posts/` onto DynamoDB + API, without GitHub commit from the upload process path.

Also includes AI-DLC inception + U1 construction design docs under `aidlc-docs/`.

## What’s in this PR

### Runtime / infra
- DynamoDB table `micahwalter-photos` (GSI1 for chronological listing, PITR)
- Process Lambda: optimize → ticket id → DynamoDB `pending` → EventBridge `PhotoPendingEnrichment` on `photo-bus` (no markdown commit)
- Public/auth API: `GET /photos`, `/featured`, `/{id}`, `PATCH /{id}` (HMAC)
- Process DLQ + IAM/CORS updates in `infra/photo-upload.yml`
- Init supports `caption` S3 metadata

### Docs
- Full inception artifacts (requirements, stories, app design, units)
- U1 functional / NFR / infrastructure design + code summary

## Out of scope (later units)
- U2 enrichment (Bedrock tags, Location geo)
- U3 multi-upload UI
- U4 browse/detail frontend cutover
- U5 edit UI, U6 galleries, U7 migrate/feeds/CLI cleanup

## Test plan
- [ ] Deploy `micahwalter-photo-upload` (or merge for `photo-upload-deploy.yml`)
- [ ] `GET https://api.micahwalter.com/photos` → `{ items, cursor }`
- [ ] Upload via `/upload` → DynamoDB row + CDN images, **no** new `content/posts` commit
- [ ] `GET /photos/{id}` and authenticated `PATCH /photos/{id}`
- [ ] Confirm `PhotoPendingEnrichment` on `photo-bus`; process failures land on DLQ

Closes nothing yet — full cutover lands with U7.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07928f49-c3fc-4afb-bd9e-d2cba8e5be02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07928f49-c3fc-4afb-bd9e-d2cba8e5be02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

