### PR TITLE
fix(ci): photo-upload deploy IAM for U1 DynamoDB/EventBridge/SQS

### DIFF
--- a/.github/workflows/photo-upload-deploy.yml
+++ b/.github/workflows/photo-upload-deploy.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Update function code only (no template change)
         if: steps.changed.outputs.template_changed == 'false'
         run: |
-          for fn in auth init process; do
+          for fn in auth init process photos-api; do
             echo "  updating photo-upload-${fn}..."
             aws lambda update-function-code \
               --function-name photo-upload-${fn} \

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -596,3 +596,11 @@
 **Context**: PR created; U1 CG still awaiting Continue to U2 if user wants to proceed in-branch.
 
 ---
+
+## Issues #103 / #104 — Deploy Failure Diagnosed
+**Timestamp**: 2026-07-16T19:25:00Z
+**User Input**: "I merged the PR but there was an error with the deploy"
+**AI Response**: Diagnosed photo-upload-deploy run 29527818052 CFN failure as missing GitHubActionsDeployPhotoUpload permissions for DynamoDB/EventBridge/SQS/EventInvokeConfig. Opened fix branch cursor/fix-photo-upload-deploy-iam-be02; IAM stack must be redeployed manually before re-running photo-upload deploy.
+**Context**: Hotfix after #106 merge; U1 stack rolled back; upload still on pre-U1 template until IAM + redeploy succeed.
+
+---

--- a/aidlc-docs/construction/u1-photo-data-plane/code/code-summary.md
+++ b/aidlc-docs/construction/u1-photo-data-plane/code/code-summary.md
@@ -21,8 +21,24 @@
 
 ## Deploy
 
+**Prerequisite:** redeploy the CI IAM stack so `GitHubActionsDeployPhotoUpload` can manage DynamoDB / EventBridge / SQS / EventInvokeConfig (these were added in U1 and are not auto-deployed):
+
+```bash
+AWS_PROFILE=www aws cloudformation deploy \
+  --stack-name micahwalter-www-github-actions \
+  --template-file infra/github-actions-role.yml \
+  --region us-east-1 \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides \
+    HostedZoneId=<hosted-zone-id> \
+    WebsiteBucketName=<website-bucket> \
+    CloudFrontDistributionId=<distribution-id>
+```
+
+Then:
+
 1. `cd infra/photo-upload-lambdas && make build`
-2. Upload zip + `aws cloudformation deploy` stack `micahwalter-photo-upload` (or merge to `main` for `photo-upload-deploy.yml`)
+2. Upload zip + `aws cloudformation deploy` stack `micahwalter-photo-upload` (or re-run `photo-upload-deploy.yml`)
 3. Confirm secret has `passcode`, `hmac`, `ticketsPasscode`
 
 ## Smoke checklist (after deploy)

--- a/infra/github-actions-role.yml
+++ b/infra/github-actions-role.yml
@@ -520,6 +520,9 @@ Resources:
               - lambda:TagResource
               - lambda:UntagResource
               - lambda:ListTags
+              - lambda:PutFunctionEventInvokeConfig
+              - lambda:GetFunctionEventInvokeConfig
+              - lambda:DeleteFunctionEventInvokeConfig
             Resource:
               - !Sub 'arn:aws:lambda:us-east-1:${AWS::AccountId}:function:photo-upload-*'
           - Effect: Allow
@@ -540,6 +543,45 @@ Resources:
               - iam:ListAttachedRolePolicies
             Resource:
               - !Sub 'arn:aws:iam::${AWS::AccountId}:role/photo-upload-*-fn-role'
+          - Effect: Allow
+            Action:
+              - dynamodb:CreateTable
+              - dynamodb:DeleteTable
+              - dynamodb:DescribeTable
+              - dynamodb:UpdateTable
+              - dynamodb:TagResource
+              - dynamodb:UntagResource
+              - dynamodb:ListTagsOfResource
+              - dynamodb:DescribeContinuousBackups
+              - dynamodb:UpdateContinuousBackups
+              - dynamodb:DescribeTimeToLive
+            Resource:
+              - !Sub 'arn:aws:dynamodb:us-east-1:${AWS::AccountId}:table/micahwalter-photos'
+              - !Sub 'arn:aws:dynamodb:us-east-1:${AWS::AccountId}:table/micahwalter-photos/index/*'
+          - Effect: Allow
+            Action:
+              - events:CreateEventBus
+              - events:DeleteEventBus
+              - events:DescribeEventBus
+              - events:TagResource
+              - events:UntagResource
+              - events:ListTagsForResource
+            Resource:
+              - !Sub 'arn:aws:events:us-east-1:${AWS::AccountId}:event-bus/photo-bus'
+          - Effect: Allow
+            Action:
+              - sqs:CreateQueue
+              - sqs:DeleteQueue
+              - sqs:GetQueueAttributes
+              - sqs:GetQueueUrl
+              - sqs:SetQueueAttributes
+              - sqs:TagQueue
+              - sqs:UntagQueue
+              - sqs:ListQueueTags
+              - sqs:AddPermission
+              - sqs:RemovePermission
+            Resource:
+              - !Sub 'arn:aws:sqs:us-east-1:${AWS::AccountId}:photo-upload-process-dlq'
           - Effect: Allow
             Action:
               - secretsmanager:CreateSecret


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the failed [`photo-upload-deploy`](https://github.com/micahwalter/micahwalter-www/actions/runs/29527818052) after merging #106.

`GitHubActionsDeployPhotoUpload` could create/update Lambda/S3/Secrets/alarms, but U1 added resources the CI role was never granted:

- DynamoDB `micahwalter-photos` (+ GSI / PITR APIs)
- EventBridge `photo-bus`
- SQS `photo-upload-process-dlq`
- Lambda `*FunctionEventInvokeConfig` (process DLQ destination)

Also updates the code-only deploy path to refresh `photo-upload-photos-api`.

## Deploy order (important)

The IAM stack is **not** auto-deployed by GitHub Actions. After merge (or from this branch locally):

1. Redeploy CI role (uses previous parameter values if you omit overrides that haven’t changed):

```bash
AWS_PROFILE=www aws cloudformation deploy \
  --stack-name micahwalter-www-github-actions \
  --template-file infra/github-actions-role.yml \
  --region us-east-1 \
  --capabilities CAPABILITY_NAMED_IAM \
  --parameter-overrides \
    HostedZoneId=<hosted-zone-id> \
    WebsiteBucketName=<website-bucket> \
    CloudFrontDistributionId=<distribution-id>
```

2. Re-run **Deploy Photo Upload Lambda Stack** (`workflow_dispatch` or push touching `infra/photo-upload.yml`).

## Test plan

- [ ] Deploy `micahwalter-www-github-actions` successfully
- [ ] Re-run photo-upload deploy → CloudFormation UPDATE_COMPLETE
- [ ] `GET https://api.micahwalter.com/photos` responds (empty list OK)
- [ ] Optional: upload smoke → DynamoDB row, no markdown commit

Related: #103 #104 #106
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07928f49-c3fc-4afb-bd9e-d2cba8e5be02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07928f49-c3fc-4afb-bd9e-d2cba8e5be02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

