### PR TITLE
fix(photos): API mapping routes + secretsmanager:UpdateSecret

### DIFF
--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -604,3 +604,11 @@
 **Context**: Hotfix after #106 merge; U1 stack rolled back; upload still on pre-U1 template until IAM + redeploy succeed.
 
 ---
+
+## Issues #103 / #104 — IAM Redeployed; Photo Stack Recovered
+**Timestamp**: 2026-07-16T19:40:00Z
+**User Input**: "AWS_PROFILE=www aws cloudformation deploy ... Successfully created/updated stack - micahwalter-www-github-actions"
+**AI Response**: Continued UPDATE_ROLLBACK_FAILED stack; deployed micahwalter-photo-upload successfully; fixed API routes relative to mapping key photos; added secretsmanager:UpdateSecret; noted bare /photos API GW 500 quirk (use /photos/). Live smoke: list 200, featured 404, auth 400, table/bus ACTIVE.
+**Context**: U1 data plane live in AWS; code/route fixes pending PR.
+
+---

--- a/aidlc-docs/construction/u1-photo-data-plane/code/code-summary.md
+++ b/aidlc-docs/construction/u1-photo-data-plane/code/code-summary.md
@@ -7,7 +7,7 @@
 
 ### Lambda package (`infra/photo-upload-lambdas/`)
 - Added `lib/photo-defaults.js`, `lib/photos-db.js`, `lib/photo-dto.js`
-- Added `photos-api.js` — GET list/featured/{id}, PATCH {id}
+- Added `photos-api.js` — GET `/` `/featured` `/{id}`, PATCH `/{id}` (relative to domain mapping `photos`)
 - Rewrote `process.js` — DynamoDB put + EventBridge enrich event; **removed GitHub commit**
 - Extended `init.js` — `caption` S3 metadata
 - Dependencies: DynamoDB Document client, EventBridge client
@@ -43,7 +43,7 @@ Then:
 
 ## Smoke checklist (after deploy)
 
-- [ ] `GET https://api.micahwalter.com/photos` → `{ items, cursor }`
+- [ ] `GET https://api.micahwalter.com/photos/` → `{ items, cursor }` (trailing slash required — API GW base-path quirk; bare `/photos` returns 500)
 - [ ] `GET .../photos/featured` → 404 until first photo or 200
 - [ ] Upload via `/upload` (title only still OK) → row in DynamoDB, images on CDN, **no** new `content/posts` commit
 - [ ] `GET .../photos/{id}` returns caption/title

--- a/infra/github-actions-role.yml
+++ b/infra/github-actions-role.yml
@@ -589,6 +589,7 @@ Resources:
               - secretsmanager:DescribeSecret
               - secretsmanager:GetSecretValue
               - secretsmanager:PutSecretValue
+              - secretsmanager:UpdateSecret
               - secretsmanager:RestoreSecret
               - secretsmanager:TagResource
               - secretsmanager:UntagResource

--- a/infra/photo-upload-lambdas/src/photos-api.js
+++ b/infra/photo-upload-lambdas/src/photos-api.js
@@ -1,6 +1,13 @@
 /**
  * HTTP API for photos — GET list/featured/{id}, PATCH {id}.
  * Routed by API Gateway routeKey on a single Lambda.
+ *
+ * Custom domain mapping key is `photos`, so public URLs are:
+ *   GET  https://api.micahwalter.com/photos
+ *   GET  https://api.micahwalter.com/photos/featured
+ *   GET  https://api.micahwalter.com/photos/{id}
+ *   PATCH https://api.micahwalter.com/photos/{id}
+ * RouteKeys below are relative to that mapping (not prefixed with /photos).
  */
 
 const { getSecret } = require('./lib/secrets');
@@ -29,11 +36,24 @@ function extractToken(event, body) {
   return body?.token;
 }
 
+function requestPath(event) {
+  const raw = event.rawPath || event.requestContext?.http?.path || '';
+  // Custom domain mapping key `photos` may leave path as /photos, /, or "".
+  return raw.replace(/^\/photos(?=\/|$)/, '') || '/';
+}
+
+function isListRoute(routeKey, method, path) {
+  if (routeKey === 'GET /' || routeKey === 'GET /photos') return true;
+  return method === 'GET' && (path === '/' || path === '');
+}
+
 exports.handler = async (event) => {
   const routeKey = event.routeKey || '';
+  const method = event.requestContext?.http?.method || event.requestContext?.httpMethod || 'GET';
+  const path = requestPath(event);
 
   try {
-    if (routeKey === 'GET /photos') {
+    if (isListRoute(routeKey, method, path)) {
       const qs = event.queryStringParameters || {};
       const limit = qs.limit;
       const cursor = qs.cursor;
@@ -45,22 +65,22 @@ exports.handler = async (event) => {
       });
     }
 
-    if (routeKey === 'GET /photos/featured') {
+    if (routeKey === 'GET /featured' || routeKey === 'GET /photos/featured' || (method === 'GET' && path === '/featured')) {
       const photo = await getFeaturedPhoto();
       if (!photo) return json(404, { message: 'No photos' });
       return json(200, toPublicPhoto(photo));
     }
 
-    if (routeKey === 'GET /photos/{id}') {
-      const id = event.pathParameters?.id;
-      if (!id) return json(400, { message: 'Missing id' });
+    if (routeKey === 'GET /{id}' || routeKey === 'GET /photos/{id}' || (method === 'GET' && /^\/[^/]+$/.test(path))) {
+      const id = event.pathParameters?.id || path.slice(1);
+      if (!id || id === 'featured') return json(404, { message: 'Not found' });
       const photo = await getPhoto(id);
       if (!photo || photo.draft) return json(404, { message: 'Not found' });
       return json(200, toPublicPhoto(photo));
     }
 
-    if (routeKey === 'PATCH /photos/{id}') {
-      const id = event.pathParameters?.id;
+    if (routeKey === 'PATCH /{id}' || routeKey === 'PATCH /photos/{id}' || (method === 'PATCH' && /^\/[^/]+$/.test(path))) {
+      const id = event.pathParameters?.id || path.slice(1);
       if (!id) return json(400, { message: 'Missing id' });
 
       let body = {};

--- a/infra/photo-upload.yml
+++ b/infra/photo-upload.yml
@@ -160,6 +160,7 @@ Resources:
       - PhotosFeaturedRoute
       - PhotosGetRoute
       - PhotosPatchRoute
+      - PhotosDefaultRoute
     Properties:
       ApiId: !Ref PhotoApi
       StageName: $default
@@ -419,32 +420,41 @@ Resources:
       RouteKey: POST /upload-url
       Target: !Sub integrations/${InitIntegration}
 
+  # Routes are relative to ApiMappingKey `photos` → https://api.micahwalter.com/photos/...
+  # Bare /photos (no trailing slash) does not match GET /; $default covers that case.
   PhotosListRoute:
     Type: AWS::ApiGatewayV2::Route
     Properties:
       ApiId: !Ref PhotoApi
-      RouteKey: GET /photos
+      RouteKey: GET /
       Target: !Sub integrations/${PhotosApiIntegration}
 
   PhotosFeaturedRoute:
     Type: AWS::ApiGatewayV2::Route
     Properties:
       ApiId: !Ref PhotoApi
-      RouteKey: GET /photos/featured
+      RouteKey: GET /featured
       Target: !Sub integrations/${PhotosApiIntegration}
 
   PhotosGetRoute:
     Type: AWS::ApiGatewayV2::Route
     Properties:
       ApiId: !Ref PhotoApi
-      RouteKey: GET /photos/{id}
+      RouteKey: GET /{id}
       Target: !Sub integrations/${PhotosApiIntegration}
 
   PhotosPatchRoute:
     Type: AWS::ApiGatewayV2::Route
     Properties:
       ApiId: !Ref PhotoApi
-      RouteKey: PATCH /photos/{id}
+      RouteKey: PATCH /{id}
+      Target: !Sub integrations/${PhotosApiIntegration}
+
+  PhotosDefaultRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref PhotoApi
+      RouteKey: $default
       Target: !Sub integrations/${PhotosApiIntegration}
 
   AuthFnPermission:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up after #106/#107 deploy recovery. The U1 photo stack is **already live** in AWS (`UPDATE_COMPLETE`); this PR syncs the repo with the route + IAM fixes applied during recovery.

### What was wrong
1. Stack stuck in `UPDATE_ROLLBACK_FAILED` (secret description update needed `secretsmanager:UpdateSecret` on the CI role).
2. Photo CRUD routes were `GET /photos…` under mapping key `photos`, so public URLs became `/photos/photos…`.
3. API Gateway returns **500** for bare `https://api.micahwalter.com/photos` (no trailing slash) before Lambda runs — use `/photos/`.

### Changes
- Routes relative to mapping: `GET /`, `GET /featured`, `GET|PATCH /{id}`, plus `$default`
- Handler accepts both mapped and legacy routeKeys
- CI role gains `secretsmanager:UpdateSecret` (already redeployed to `micahwalter-www-github-actions`)

### Live smoke (already verified)
- `GET /photos/` → `200` `{items:[],…}`
- `GET /photos/featured` → `404` No photos
- `POST /photos/auth` → `400` Passcode is required
- Table `micahwalter-photos` ACTIVE, bus `photo-bus` exists

### After merge
CI photo-upload deploy should succeed (IAM already updated). No manual stack deploy required unless you want to re-run for confirmation.

Related: #103 #104 #106 #107
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07928f49-c3fc-4afb-bd9e-d2cba8e5be02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07928f49-c3fc-4afb-bd9e-d2cba8e5be02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

