### PR TITLE
docs(aidlc): record U1 photo data plane deploy success

### DIFF
--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -3,14 +3,15 @@
 ## Project Information
 - **Project Type**: Brownfield
 - **Start Date**: 2026-07-16T15:24:00Z
-- **Current Stage**: CONSTRUCTION — U1 Code Generation (approval gate after implementation)
+- **Current Stage**: CONSTRUCTION — U1 Code Generation (approval gate; deployed to AWS)
 - **Engagement Status**: In progress
-- **Branch:** `cursor/photo-metadata-dynamodb-be02`
+- **Branch:** `main` (U1 + deploy fixes merged via #106 / #107 / #108)
 
 ## Active Engagement — Issues #103 / #104
-- **Current unit:** U1 Photo data plane — **implementation complete, awaiting Continue**
+- **Current unit:** U1 Photo data plane — **implemented + deployed**; awaiting Continue to U2
 - **Code summary:** `aidlc-docs/construction/u1-photo-data-plane/code/code-summary.md`
-- **Next after U1 CG approve:** U2 Enrichment (Functional Design…) or user may request deploy smoke first
+- **Live:** `GET https://api.micahwalter.com/photos/` → 200; table `micahwalter-photos`; bus `photo-bus`
+- **Next after U1 CG approve:** U2 Enrichment (Functional Design…)
 
 ## Stage Progress
 
@@ -22,7 +23,7 @@
 - [x] NFR Requirements (approved)
 - [x] NFR Design (approved)
 - [x] Infrastructure Design (approved)
-- [x] Code Generation (implemented; awaiting Continue)
+- [x] Code Generation (implemented + deployed; awaiting Continue)
 
 ### CONSTRUCTION — U2–U7 + Build and Test
 - [ ] Pending (Build and Test after all units)

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -612,3 +612,12 @@
 **Context**: U1 data plane live in AWS; code/route fixes pending PR.
 
 ---
+
+## Issues #103 / #104 — U1 Deploy Confirmed Success
+**Timestamp**: 2026-07-16T19:56:00Z
+**User Input**: "ok merged and deployed with success"
+**AI Response**: Confirmed photo-upload-deploy run 29529880145 success for #108; live smoke /photos/ 200. Updated aidlc-state; presenting U1 Code Generation Continue gate for U2.
+**Approval Prompt**: "Code Generation Complete - U1. Request Changes or Continue to Next Stage (U2 Functional Design)."
+**Context**: CONSTRUCTION — U1 Code Generation approval gate after successful production deploy.
+
+---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docs-only: mark U1 as deployed after #108 and keep the Continue gate open for U2 Enrichment.

No runtime changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07928f49-c3fc-4afb-bd9e-d2cba8e5be02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07928f49-c3fc-4afb-bd9e-d2cba8e5be02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

