### PR TITLE
fix(ci): allow cloudfront:GetFunction for infra deploy

### DIFF
--- a/infra/github-actions-role.yml
+++ b/infra/github-actions-role.yml
@@ -828,6 +828,7 @@ Resources:
               - !Sub 'arn:aws:cloudformation:us-east-2:${AWS::AccountId}:stack/micahwalter-www-secondary/*'
           - Effect: Allow
             Action:
+              - cloudfront:GetFunction
               - cloudfront:DescribeFunction
               - cloudfront:CreateFunction
               - cloudfront:UpdateFunction


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Redeploy of `micahwalter-www` failed because `GitHubActionsDeployRole` lacked `cloudfront:GetFunction` (needed when CFN resolves `FunctionARN` on the distribution).

Also: the three post-#110 deploy failures were largely due to the **IAM role stack not being redeployed** after U6/U7 policy additions. That stack has now been redeployed locally with `www` (includes galleries/geo/secondary/feed perms + this GetFunction fix).

## Test plan
- [x] `aws cloudformation deploy` of `micahwalter-www-github-actions` succeeded
- [ ] Re-run failed workflows: photo-upload, photo-upload-secondary, infra-deploy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07928f49-c3fc-4afb-bd9e-d2cba8e5be02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07928f49-c3fc-4afb-bd9e-d2cba8e5be02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

