### PR TITLE
fix(photos): remove $default route breaking /upload CORS login

### DIFF
--- a/infra/photo-upload-secondary.yml
+++ b/infra/photo-upload-secondary.yml
@@ -74,7 +74,6 @@ Resources:
       - PhotosFeaturedRoute
       - PhotosGetRoute
       - PhotosPatchRoute
-      - PhotosDefaultRoute
     Properties:
       ApiId: !Ref PhotoApi
       StageName: $default
@@ -265,12 +264,8 @@ Resources:
       RouteKey: PATCH /{id}
       Target: !Sub integrations/${PhotosApiIntegration}
 
-  PhotosDefaultRoute:
-    Type: AWS::ApiGatewayV2::Route
-    Properties:
-      ApiId: !Ref PhotoApi
-      RouteKey: $default
-      Target: !Sub integrations/${PhotosApiIntegration}
+  # Do NOT add a $default route — on HTTP APIs it intercepts OPTIONS preflight
+  # and returns 500, which breaks browser CORS login on /photos/auth.
 
   AuthFnPermission:
     Type: AWS::Lambda::Permission

--- a/infra/photo-upload.yml
+++ b/infra/photo-upload.yml
@@ -191,7 +191,6 @@ Resources:
       - PhotosFeaturedRoute
       - PhotosGetRoute
       - PhotosPatchRoute
-      - PhotosDefaultRoute
     Properties:
       ApiId: !Ref PhotoApi
       StageName: $default
@@ -593,7 +592,8 @@ Resources:
       RouteKey: PATCH /galleries/{slug}
       Target: !Sub integrations/${PhotosApiIntegration}
 
-  # Bare /photos (no trailing slash) does not match GET /; $default covers that case.
+  # List: GET /photos/ (trailing slash). Do NOT add a $default route — on HTTP APIs
+  # it intercepts OPTIONS preflight and returns 500, which breaks browser CORS login.
   PhotosListRoute:
     Type: AWS::ApiGatewayV2::Route
     Properties:
@@ -620,13 +620,6 @@ Resources:
     Properties:
       ApiId: !Ref PhotoApi
       RouteKey: PATCH /{id}
-      Target: !Sub integrations/${PhotosApiIntegration}
-
-  PhotosDefaultRoute:
-    Type: AWS::ApiGatewayV2::Route
-    Properties:
-      ApiId: !Ref PhotoApi
-      RouteKey: $default
       Target: !Sub integrations/${PhotosApiIntegration}
 
   AuthFnPermission:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Browser login on `/upload` failed because API Gateway HTTP API `$default` routes intercepted `OPTIONS` preflight and returned **500**, so the browser never reached `POST /photos/auth`.

## Changes
- Remove `PhotosDefaultRoute` (`$default`) from `infra/photo-upload.yml` and `infra/photo-upload-secondary.yml`
- Document why `$default` must not be re-added (CORS preflight)

## Already applied live
`$default` was removed from the primary (us-east-1) and secondary (us-east-2) APIs so login works now. This PR keeps the next CloudFormation deploy from recreating it.

Verified after the live fix:
- `OPTIONS /photos/auth` → **204**
- `POST /photos/auth` (wrong passcode) → **401**

## Note
Bare `GET /photos` (no trailing slash) will 404; clients should use `GET /photos/` (the site client already does).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07928f49-c3fc-4afb-bd9e-d2cba8e5be02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07928f49-c3fc-4afb-bd9e-d2cba8e5be02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

