### PR TITLE
fix(photos): GPS hemisphere for Apple XMP (#117)

### DIFF
--- a/infra/photo-upload-lambdas/src/enrich.js
+++ b/infra/photo-upload-lambdas/src/enrich.js
@@ -42,27 +42,36 @@ async function loadFirstExisting(keys) {
   return null;
 }
 
-function parsePhotoId(event) {
-  if (event?.detail?.photoId) return String(event.detail.photoId);
+function parseDetail(event) {
+  if (event?.detail && typeof event.detail === 'object') return event.detail;
   if (typeof event?.detail === 'string') {
     try {
-      const d = JSON.parse(event.detail);
-      if (d.photoId) return String(d.photoId);
+      return JSON.parse(event.detail);
     } catch {
-      /* ignore */
+      return {};
     }
   }
+  return {};
+}
+
+function parsePhotoId(event) {
+  const detail = parseDetail(event);
+  if (detail.photoId) return String(detail.photoId);
   return null;
 }
 
-async function enrichPhoto(photoId) {
+function parseForce(event) {
+  return parseDetail(event).force === true;
+}
+
+async function enrichPhoto(photoId, { force = false } = {}) {
   const photo = await getPhoto(photoId);
   if (!photo) {
     console.warn(`enrich: photo ${photoId} not found`);
     return { ok: false, reason: 'not_found' };
   }
 
-  if (photo.enrichmentStatus === 'complete') {
+  if (photo.enrichmentStatus === 'complete' && !force) {
     console.log(`enrich: photo ${photoId} already complete — no-op`);
     return { ok: true, skipped: true };
   }
@@ -136,7 +145,10 @@ async function enrichPhoto(photoId) {
     console.error(`enrich Bedrock step failed for ${photoId}:`, err.message);
   }
 
-  const tags = mergeTags(photo.tags || [], geoTags, aiTags);
+  // Force re-enrich rebuilds tags from defaults + new geo/AI so bad place tags
+  // (e.g. wrong-hemisphere geocode) do not stick forever via merge-only updates.
+  const baseTags = force ? ['photography'] : (photo.tags || []);
+  const tags = mergeTags(baseTags, geoTags, aiTags);
 
   const fields = {
     tags,
@@ -149,8 +161,8 @@ async function enrichPhoto(photoId) {
     fields.publicLatitude = publicLatitude;
     fields.publicLongitude = publicLongitude;
   }
-  if (city != null) fields.city = city;
-  if (country != null) fields.country = country;
+  if (force || city != null) fields.city = city;
+  if (force || country != null) fields.country = country;
 
   try {
     await updatePhotoEnrichment(photoId, fields);
@@ -189,7 +201,7 @@ exports.handler = async (event) => {
       console.warn('enrich: missing photoId', JSON.stringify(ev)?.slice(0, 200));
       continue;
     }
-    await enrichPhoto(photoId);
+    await enrichPhoto(photoId, { force: parseForce(ev) });
   }
 
   return { ok: true };
@@ -197,3 +209,4 @@ exports.handler = async (event) => {
 
 exports.enrichPhoto = enrichPhoto;
 exports.parsePhotoId = parsePhotoId;
+exports.parseForce = parseForce;

--- a/infra/photo-upload-lambdas/src/lib/exif.js
+++ b/infra/photo-upload-lambdas/src/lib/exif.js
@@ -7,9 +7,69 @@
 const ExifReader = require('exifreader');
 const sharp = require('sharp');
 
+/**
+ * Pull N/S/E/W from a ref tag or from a coordinate string that embeds it
+ * (Apple XMP often uses "73,39.3W" → description "73.655W").
+ */
+function hemisphereFromRef(refTag) {
+  if (refTag == null) return null;
+  const candidates = [];
+  if (refTag.value != null) {
+    if (Array.isArray(refTag.value)) {
+      candidates.push(refTag.value.join(''));
+      candidates.push(...refTag.value);
+    } else {
+      candidates.push(refTag.value);
+    }
+  }
+  if (refTag.description != null) candidates.push(refTag.description);
+
+  for (const c of candidates) {
+    const letter = hemisphereFromString(c);
+    if (letter) return letter;
+  }
+  return null;
+}
+
+function hemisphereFromString(raw) {
+  if (raw == null) return null;
+  const s = String(raw).trim().toUpperCase();
+  if (!s) return null;
+  // Word forms first — "West longitude" must not match trailing E in "longitude".
+  if (/\bNORTH\b/.test(s) || s === 'N') return 'N';
+  if (/\bSOUTH\b/.test(s) || s === 'S') return 'S';
+  if (/\bEAST\b/.test(s) || s === 'E') return 'E';
+  if (/\bWEST\b/.test(s) || s === 'W') return 'W';
+  // Trailing hemisphere after a coordinate (e.g. "73.655W", "40.8 S")
+  const trailing = s.match(/[\d.]\s*([NSEW])\s*$/);
+  if (trailing) return trailing[1];
+  return null;
+}
+
+function applyHemisphere(degrees, hemi, negativeLetter) {
+  if (degrees == null || Number.isNaN(degrees)) return null;
+  if (hemi === negativeLetter) return -Math.abs(degrees);
+  if (hemi && hemi !== negativeLetter) return Math.abs(degrees);
+  // No hemisphere hint — keep sign if already present (signed decimal).
+  return degrees;
+}
+
+function parseDecimalCoord(raw) {
+  if (raw == null) return { degrees: null, hemi: null };
+  if (typeof raw === 'number') {
+    return { degrees: raw, hemi: null };
+  }
+  const s = String(raw).trim();
+  const hemi = hemisphereFromString(s);
+  const n = parseFloat(s);
+  if (Number.isNaN(n)) return { degrees: null, hemi };
+  return { degrees: n, hemi };
+}
+
 function dmsToDecimal(dms, ref) {
-  if (!dms) return null;
+  if (!dms && dms !== 0) return null;
   let degrees;
+  let embeddedHemi = null;
   if (typeof dms === 'number') {
     degrees = dms;
   } else if (Array.isArray(dms)) {
@@ -20,19 +80,22 @@ function dmsToDecimal(dms, ref) {
     });
     degrees = d + (m || 0) / 60 + (s || 0) / 3600;
   } else if (typeof dms === 'string') {
-    const n = parseFloat(dms);
-    if (Number.isNaN(n)) return null;
-    degrees = n;
+    const parsed = parseDecimalCoord(dms);
+    if (parsed.degrees == null) return null;
+    degrees = parsed.degrees;
+    embeddedHemi = parsed.hemi;
   } else {
     return null;
   }
-  const r = String(ref || '').toUpperCase();
-  if (r === 'S' || r === 'W') degrees = -Math.abs(degrees);
+  const hemi = hemisphereFromString(ref) || embeddedHemi;
+  // Caller passes lat or lon ref; S and W both mean "negative".
+  if (hemi === 'S' || hemi === 'W') return -Math.abs(degrees);
+  if (hemi === 'N' || hemi === 'E') return Math.abs(degrees);
   return degrees;
 }
 
 /**
- * Extract precise GPS from ExifReader tags.
+ * Extract precise GPS from ExifReader tags (flat or expanded.exif).
  */
 function extractGpsFromTags(tags) {
   try {
@@ -43,25 +106,26 @@ function extractGpsFromTags(tags) {
     let latitude;
     let longitude;
 
+    const latRefHemi = hemisphereFromRef(tags.GPSLatitudeRef);
+    const lonRefHemi = hemisphereFromRef(tags.GPSLongitudeRef);
+
     if (latTag.description != null && !Number.isNaN(parseFloat(latTag.description))) {
-      latitude = parseFloat(latTag.description);
-      const latRef = tags.GPSLatitudeRef?.value?.[0] || tags.GPSLatitudeRef?.description;
-      if (String(latRef).toUpperCase().startsWith('S') && latitude > 0) latitude = -latitude;
+      const parsed = parseDecimalCoord(latTag.description);
+      latitude = applyHemisphere(parsed.degrees, parsed.hemi || latRefHemi, 'S');
     } else {
       latitude = dmsToDecimal(
         latTag.value,
-        tags.GPSLatitudeRef?.value?.[0] || tags.GPSLatitudeRef?.description,
+        latRefHemi || tags.GPSLatitudeRef?.value?.[0] || tags.GPSLatitudeRef?.description,
       );
     }
 
     if (lonTag.description != null && !Number.isNaN(parseFloat(lonTag.description))) {
-      longitude = parseFloat(lonTag.description);
-      const lonRef = tags.GPSLongitudeRef?.value?.[0] || tags.GPSLongitudeRef?.description;
-      if (String(lonRef).toUpperCase().startsWith('W') && longitude > 0) longitude = -longitude;
+      const parsed = parseDecimalCoord(lonTag.description);
+      longitude = applyHemisphere(parsed.degrees, parsed.hemi || lonRefHemi, 'W');
     } else {
       longitude = dmsToDecimal(
         lonTag.value,
-        tags.GPSLongitudeRef?.value?.[0] || tags.GPSLongitudeRef?.description,
+        lonRefHemi || tags.GPSLongitudeRef?.value?.[0] || tags.GPSLongitudeRef?.description,
       );
     }
 
@@ -77,10 +141,30 @@ function extractGpsFromTags(tags) {
   }
 }
 
+/**
+ * Prefer ExifReader's expanded gps group (signed decimals from EXIF IFD).
+ * Fall back to flat/XMP tags, including Apple-style "73.655W" descriptions.
+ */
 async function extractGps(buffer) {
   try {
-    const tags = ExifReader.load(buffer);
-    return extractGpsFromTags(tags);
+    const expanded = ExifReader.load(buffer, { expanded: true });
+    const gps = expanded.gps;
+    if (gps && gps.Latitude != null && gps.Longitude != null) {
+      const latitude = Number(gps.Latitude);
+      const longitude = Number(gps.Longitude);
+      if (
+        !Number.isNaN(latitude)
+        && !Number.isNaN(longitude)
+        && Math.abs(latitude) <= 90
+        && Math.abs(longitude) <= 180
+      ) {
+        return { latitude, longitude };
+      }
+    }
+
+    // Flat merge (XMP may overwrite EXIF) — still handles embedded N/S/E/W.
+    const flat = ExifReader.load(buffer);
+    return extractGpsFromTags(flat);
   } catch (err) {
     console.warn('Could not read GPS EXIF:', err.message);
     return { latitude: null, longitude: null };
@@ -152,4 +236,13 @@ async function extractExif(buffer) {
   return exif;
 }
 
-module.exports = { extractExif, extractGps, extractGpsFromTags, dmsToDecimal };
+module.exports = {
+  extractExif,
+  extractGps,
+  extractGpsFromTags,
+  dmsToDecimal,
+  hemisphereFromString,
+  hemisphereFromRef,
+  parseDecimalCoord,
+  applyHemisphere,
+};

--- a/infra/photo-upload-lambdas/src/lib/exif.test.js
+++ b/infra/photo-upload-lambdas/src/lib/exif.test.js
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for GPS hemisphere parsing (issue #117).
+ * Run: node --test src/lib/exif.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  extractGpsFromTags,
+  hemisphereFromString,
+  parseDecimalCoord,
+  applyHemisphere,
+  dmsToDecimal,
+} = require('./exif');
+
+describe('hemisphereFromString', () => {
+  it('reads trailing letter from Apple XMP-style decimals', () => {
+    assert.equal(hemisphereFromString('73.655W'), 'W');
+    assert.equal(hemisphereFromString('40.863N'), 'N');
+    assert.equal(hemisphereFromString('73.655 W'), 'W');
+  });
+
+  it('reads word forms from ExifReader ref descriptions', () => {
+    assert.equal(hemisphereFromString('West longitude'), 'W');
+    assert.equal(hemisphereFromString('East longitude'), 'E');
+    assert.equal(hemisphereFromString('North latitude'), 'N');
+    assert.equal(hemisphereFromString('South latitude'), 'S');
+  });
+});
+
+describe('parseDecimalCoord + applyHemisphere', () => {
+  it('negates west longitude embedded in description without a ref tag', () => {
+    const parsed = parseDecimalCoord('73.655W');
+    assert.equal(parsed.degrees, 73.655);
+    assert.equal(parsed.hemi, 'W');
+    assert.equal(applyHemisphere(parsed.degrees, parsed.hemi, 'W'), -73.655);
+  });
+});
+
+describe('extractGpsFromTags', () => {
+  it('applies West from GPSLongitudeRef.value', () => {
+    const gps = extractGpsFromTags({
+      GPSLatitude: { description: '40.863' },
+      GPSLatitudeRef: { value: ['N'], description: 'North latitude' },
+      GPSLongitude: { description: '73.655' },
+      GPSLongitudeRef: { value: ['W'], description: 'West longitude' },
+    });
+    assert.equal(gps.latitude, 40.863);
+    assert.equal(gps.longitude, -73.655);
+  });
+
+  it('applies West from description when ref tag is missing (XMP-only)', () => {
+    // Reproduces issue #117: parseFloat("73.655W") is positive and ref is absent.
+    const gps = extractGpsFromTags({
+      GPSLatitude: { description: '40.863N' },
+      GPSLongitude: { description: '73.655W' },
+    });
+    assert.equal(gps.latitude, 40.863);
+    assert.equal(gps.longitude, -73.655);
+  });
+
+  it('does not flip an already-negative longitude', () => {
+    const gps = extractGpsFromTags({
+      GPSLatitude: { description: '40.829' },
+      GPSLatitudeRef: { value: ['N'], description: 'North latitude' },
+      GPSLongitude: { description: '-73.655' },
+      GPSLongitudeRef: { value: ['W'], description: 'West longitude' },
+    });
+    assert.equal(gps.longitude, -73.655);
+  });
+
+  it('keeps eastern longitudes positive', () => {
+    const gps = extractGpsFromTags({
+      GPSLatitude: { description: '40.5' },
+      GPSLatitudeRef: { value: ['N'], description: 'North latitude' },
+      GPSLongitude: { description: '72.8' },
+      GPSLongitudeRef: { value: ['E'], description: 'East longitude' },
+    });
+    assert.equal(gps.longitude, 72.8);
+  });
+});
+
+describe('dmsToDecimal', () => {
+  it('handles rational arrays with W ref', () => {
+    const lon = dmsToDecimal(
+      [[73, 1], [39, 1], [18, 1]],
+      'W',
+    );
+    assert.ok(Math.abs(lon - (-73.655)) < 0.001);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix enrichment GPS parsing so Apple/XMP longitudes like `73.655W` keep the West sign (issue #117 mapped Port Washington–area shots to Kyrgyzstan)
- Prefer ExifReader `expanded` GPS when available; harden N/S/E/W extraction from ref tags and embedded coordinate suffixes
- Add `force: true` on enrichment events so re-runs can replace bad place tags instead of merge-only sticking them
- Unit tests for the hemisphere cases

## Test plan
- [x] `node --test infra/photo-upload-lambdas/src/lib/exif.test.js`
- [x] Local force re-enrich of photo 172 → Glen Cove, USA / `publicLongitude: -73.655` with Bedrock tags
- [ ] Merge triggers `photo-upload-deploy.yml`; confirm `photo-upload-enrich` updates
- [ ] Optional: upload a new iPhone photo with location and confirm western coords stay negative


Made with [Cursor](https://cursor.com)