### PR TITLE
chore: allocate post id 173 for Photos without the deploy

### DIFF
--- a/content/posts/2026-07-20-photos-without-the-deploy/index.md
+++ b/content/posts/2026-07-20-photos-without-the-deploy/index.md
@@ -1,5 +1,5 @@
 ---
-# TODO: backfill id from the ticket server (POST /tickets/next); optional for blog posts
+id: 173
 title: "Photos without the deploy"
 publishedAt: "2026-07-20"
 excerpt: "Uploading a photo from my phone worked, but publishing it still meant a full static rebuild. Moving photo metadata to DynamoDB and serving it from an API turned a four minute wait into a few seconds, and taught me a couple of lessons about EXIF data along the way."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Backfills `id: 173` on the live post [Photos without the deploy](https://www.micahwalter.com/posts/photos-without-the-deploy) using IAM-authenticated `POST /tickets/allocate` after #123 shipped and `micahwalter-www-github-actions` was redeployed with `GitHubActionsTicketsAllocate`.

## Test plan
- [x] Signed allocate returned `{ "id": 173 }`
- [x] Frontmatter updated locally
- [ ] Merge + site deploy
- [ ] Spot-check live post still renders

Follow-up from #121 / PR #123.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-474e2838-a12d-497a-8e3b-906fc255ad83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-474e2838-a12d-497a-8e3b-906fc255ad83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

