### PR TITLE
fix: Exposure post-merge IAM + CloudFront routing (#127)

### DIFF
--- a/aidlc-docs/construction/build-and-test/build-instructions.md
+++ b/aidlc-docs/construction/build-and-test/build-instructions.md
@@ -71,7 +71,7 @@ Push/merge so `deploy.yml` builds with `NEXT_PUBLIC_PHOTO_API_URL` set. Optional
 | `photo-upload-deploy.yml` | Lambda zip + `micahwalter-photo-upload` CFN (tables, APIs, orchestrator, Sunday schedule) |
 | Newsletter workflows | Unchanged — Exposure reuses `newsletter-bus` |
 
-**One-time before the first Exposure CFN deploy via CI:** redeploy the IAM stack so `GitHubActionsDeployPhotoUpload` includes exposures/counter DynamoDB, Scheduler, and PassRole for `photo-upload-exposure-scheduler-role`:
+**One-time before the first Exposure CFN deploy via CI:** redeploy the IAM stack so it attaches `GitHubActionsDeployExposure` (separate managed policy — adding these statements to `GitHubActionsDeployPhotoUpload` exceeds the 6,144-byte IAM policy size quota):
 
 ```bash
 AWS_PROFILE=www aws cloudformation deploy \

--- a/infra/github-actions-role.yml
+++ b/infra/github-actions-role.yml
@@ -543,8 +543,6 @@ Resources:
               - iam:ListAttachedRolePolicies
             Resource:
               - !Sub 'arn:aws:iam::${AWS::AccountId}:role/photo-upload-*-fn-role'
-              # EventBridge Scheduler invoke role for Exposure Sunday send (not *-fn-role)
-              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/photo-upload-exposure-scheduler-role'
           - Effect: Allow
             Action:
               - dynamodb:CreateTable
@@ -562,10 +560,6 @@ Resources:
               - !Sub 'arn:aws:dynamodb:us-east-1:${AWS::AccountId}:table/micahwalter-photos/index/*'
               - !Sub 'arn:aws:dynamodb:us-east-1:${AWS::AccountId}:table/micahwalter-galleries'
               - !Sub 'arn:aws:dynamodb:us-east-1:${AWS::AccountId}:table/micahwalter-galleries/index/*'
-              - !Sub 'arn:aws:dynamodb:us-east-1:${AWS::AccountId}:table/micahwalter-exposures'
-              - !Sub 'arn:aws:dynamodb:us-east-1:${AWS::AccountId}:table/micahwalter-exposures/index/*'
-              - !Sub 'arn:aws:dynamodb:us-east-1:${AWS::AccountId}:table/micahwalter-exposure-counter'
-              - !Sub 'arn:aws:dynamodb:us-east-1:${AWS::AccountId}:table/micahwalter-exposure-counter/index/*'
           - Effect: Allow
             Action:
               - events:CreateEventBus
@@ -592,31 +586,6 @@ Resources:
               - !Sub 'arn:aws:events:us-east-1:${AWS::AccountId}:rule/photo-bus/*'
               - !Sub 'arn:aws:events:us-east-1:${AWS::AccountId}:archive/photo-bus-archive'
               - !Sub 'arn:aws:events:us-east-1:${AWS::AccountId}:rule/photo-feed-publisher-hourly'
-          # Exposure Sunday send — EventBridge Scheduler (AWS::Scheduler::Schedule)
-          - Effect: Allow
-            Action:
-              - scheduler:CreateSchedule
-              - scheduler:UpdateSchedule
-              - scheduler:DeleteSchedule
-              - scheduler:GetSchedule
-              - scheduler:ListSchedules
-              - scheduler:CreateScheduleGroup
-              - scheduler:DeleteScheduleGroup
-              - scheduler:GetScheduleGroup
-              - scheduler:ListScheduleGroups
-              - scheduler:TagResource
-              - scheduler:UntagResource
-              - scheduler:ListTagsForResource
-            Resource:
-              - !Sub 'arn:aws:scheduler:us-east-1:${AWS::AccountId}:schedule/*/*'
-              - !Sub 'arn:aws:scheduler:us-east-1:${AWS::AccountId}:schedule-group/*'
-          - Effect: Allow
-            Action:
-              - iam:CreateServiceLinkedRole
-            Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/aws-service-role/scheduler.amazonaws.com/AWSServiceRoleForScheduler'
-            Condition:
-              StringEquals:
-                iam:AWSServiceName: scheduler.amazonaws.com
           - Effect: Allow
             Action:
               - geo:CreatePlaceIndex
@@ -725,6 +694,77 @@ Resources:
               - cloudwatch:ListTagsForResource
             Resource:
               - !Sub 'arn:aws:cloudwatch:us-east-2:${AWS::AccountId}:alarm:photo-upload-*'
+
+  # Exposure (#127) — separate managed policy so GitHubActionsDeployPhotoUpload
+  # stays under the 6,144-byte IAM managed-policy size quota.
+  ExposureDeployPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: GitHubActionsDeployExposure
+      Roles:
+        - !Ref GitHubActionsRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - iam:PassRole
+              - iam:CreateRole
+              - iam:DeleteRole
+              - iam:GetRole
+              - iam:UpdateRole
+              - iam:TagRole
+              - iam:UntagRole
+              - iam:PutRolePolicy
+              - iam:DeleteRolePolicy
+              - iam:GetRolePolicy
+              - iam:ListRolePolicies
+              - iam:AttachRolePolicy
+              - iam:DetachRolePolicy
+              - iam:ListAttachedRolePolicies
+            Resource:
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/photo-upload-exposure-scheduler-role'
+          - Effect: Allow
+            Action:
+              - dynamodb:CreateTable
+              - dynamodb:DeleteTable
+              - dynamodb:DescribeTable
+              - dynamodb:UpdateTable
+              - dynamodb:TagResource
+              - dynamodb:UntagResource
+              - dynamodb:ListTagsOfResource
+              - dynamodb:DescribeContinuousBackups
+              - dynamodb:UpdateContinuousBackups
+              - dynamodb:DescribeTimeToLive
+            Resource:
+              - !Sub 'arn:aws:dynamodb:us-east-1:${AWS::AccountId}:table/micahwalter-exposures'
+              - !Sub 'arn:aws:dynamodb:us-east-1:${AWS::AccountId}:table/micahwalter-exposures/index/*'
+              - !Sub 'arn:aws:dynamodb:us-east-1:${AWS::AccountId}:table/micahwalter-exposure-counter'
+              - !Sub 'arn:aws:dynamodb:us-east-1:${AWS::AccountId}:table/micahwalter-exposure-counter/index/*'
+          - Effect: Allow
+            Action:
+              - scheduler:CreateSchedule
+              - scheduler:UpdateSchedule
+              - scheduler:DeleteSchedule
+              - scheduler:GetSchedule
+              - scheduler:ListSchedules
+              - scheduler:CreateScheduleGroup
+              - scheduler:DeleteScheduleGroup
+              - scheduler:GetScheduleGroup
+              - scheduler:ListScheduleGroups
+              - scheduler:TagResource
+              - scheduler:UntagResource
+              - scheduler:ListTagsForResource
+            Resource:
+              - !Sub 'arn:aws:scheduler:us-east-1:${AWS::AccountId}:schedule/*/*'
+              - !Sub 'arn:aws:scheduler:us-east-1:${AWS::AccountId}:schedule-group/*'
+          - Effect: Allow
+            Action:
+              - iam:CreateServiceLinkedRole
+            Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/aws-service-role/scheduler.amazonaws.com/AWSServiceRoleForScheduler'
+            Condition:
+              StringEquals:
+                iam:AWSServiceName: scheduler.amazonaws.com
 
   TicketsDeployPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -336,6 +336,13 @@ Resources:
             return request;
           }
 
+          // Static-export shell for Exposure issues: /exposures/<digits> → 0.html
+          var exposureShell = rewriteExposureDetailShell(uri);
+          if (exposureShell) {
+            request.uri = exposureShell;
+            return request;
+          }
+
           if (uri === '/' || uri === '') {
             request.uri = '/index.html';
           } else {
@@ -404,6 +411,21 @@ Resources:
           return null;
         }
 
+        function rewriteExposureDetailShell(uri) {
+          var path = uri;
+          if (path.charAt(0) === '/') {
+            path = path.slice(1);
+          }
+          if (path.endsWith('/')) {
+            path = path.slice(0, -1);
+          }
+          var parts = path.split('/');
+          if (parts.length === 2 && parts[0] === 'exposures' && isAllDigits(parts[1])) {
+            return '/exposures/0.html';
+          }
+          return null;
+        }
+
         function isValidMonth(month) {
           if (month.length !== 2) return false;
           var n = parseInt(month, 10);
@@ -435,7 +457,7 @@ Resources:
 
         function isReservedSegment(seg) {
           var reserved = {
-            'about': 1, 'colophon': 1, 'emails': 1, 'galleries': 1,
+            'about': 1, 'colophon': 1, 'emails': 1, 'exposures': 1, 'galleries': 1,
             'micro': 1, 'newsletter': 1, 'photos': 1, 'posts': 1,
             'sketches': 1, 'upload': 1, 'tags': 1, 'topics': 1, 'page': 1
           };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Post-merge follow-ups for Exposure (#127 / #128).

### 1. IAM policy size (`GitHubActionsDeployExposure`)
Redeploying `micahwalter-www-github-actions` failed with `PolicySize: 6144` on `GitHubActionsDeployPhotoUpload`. Exposure DynamoDB/Scheduler/PassRole permissions now live in a **separate** managed policy `GitHubActionsDeployExposure`.

### 2. CloudFront routing for `/exposures`
`/exposures` was treated as a legacy post slug and 301’d to `/posts/exposures`. Added `exposures` to reserved segments and a `/exposures/<digits>` → `0.html` shell rewrite (same pattern as photos).

## Already applied in AWS (this session)
- IAM stack updated (policy attached)
- `micahwalter-photo-upload` CFN deployed (API, tables, Sunday schedule)
- `micahwalter-www` CFN updated (CloudFront function)

## Verify
- `GET https://api.micahwalter.com/exposures/` → `{ "items": [], ... }`
- `https://www.micahwalter.com/exposures` → 200
- Schedule `exposure-sunday-send` ENABLED (`cron(0 9 ? * SUN *)` America/New_York)

This PR keeps `main` in sync with the live templates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa8df-a93c-70c7-a8ab-3c7b83066caf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa8df-a93c-70c7-a8ab-3c7b83066caf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

