### PR TITLE
fix(ci): always refresh photo-upload Lambda code on deploy

### DIFF
--- a/.github/workflows/photo-upload-deploy.yml
+++ b/.github/workflows/photo-upload-deploy.yml
@@ -77,8 +77,11 @@ jobs:
               LambdaArtifactsBucket=${{ env.ARTIFACTS_BUCKET }} \
               LambdaArtifactsKeyPrefix=${{ env.ARTIFACTS_PREFIX }}
 
-      - name: Update function code only (no template change)
-        if: steps.changed.outputs.template_changed == 'false'
+      # Always refresh function code from the zip we just uploaded.
+      # CloudFormation will not redeploy Lambda code when the S3 key is unchanged,
+      # so a template-only deploy previously left functions on stale packages
+      # (e.g. Exposure routes existed but photos-api still ran pre-Exposure code).
+      - name: Update Lambda function code
         run: |
           for fn in auth init process photos-api enrich feed-publisher exposures-api exposure-orchestrator; do
             echo "  updating photo-upload-${fn}..."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After merging Exposure (#128), CloudFormation created the `POST /{id}/exposure-test` route but **did not refresh Lambda code** (same S3 key → CFN skips code update). Live `photos-api` still ran the pre-Exposure package, so the UI got:

`Could not send test Exposure` → API `404 Unknown route: POST /{id}/exposure-test`

## Fix
- **Live:** already ran `update-function-code` for all photo-upload Lambdas (verified: unauthenticated test now returns `401`).
- **CI:** always run `update-function-code` after uploading the zip, including when the template changed.

## Verify
Retry **Send test Exposure** on `/upload` (while logged in).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa8df-a93c-70c7-a8ab-3c7b83066caf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa8df-a93c-70c7-a8ab-3c7b83066caf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

