### PR TITLE
feat(upload): Eligible for Exposure on multi-photo form

### DIFF
--- a/app/upload/UploadForm.tsx
+++ b/app/upload/UploadForm.tsx
@@ -20,6 +20,7 @@ type UploadItem = {
   title: string;
   caption: string;
   featured: boolean;
+  exposureEligible: boolean;
   status: ItemStatus;
   progress: number | null;
   errorMessage: string | null;
@@ -91,6 +92,7 @@ export default function UploadForm({ token, onSessionExpired }: UploadFormProps)
         title: titleFromFilename(file.name),
         caption: "",
         featured: false,
+        exposureEligible: false,
         status: "pending",
         progress: null,
         errorMessage: null,
@@ -158,6 +160,7 @@ export default function UploadForm({ token, onSessionExpired }: UploadFormProps)
           title: item.title.trim(),
           caption: item.caption,
           featured: item.featured,
+          exposureEligible: item.exposureEligible,
         });
         await putToPresignedUrl(url, headers, item.file, (percent) => {
           updateItem(item.localId, { progress: percent });
@@ -287,6 +290,19 @@ export default function UploadForm({ token, onSessionExpired }: UploadFormProps)
                       className="h-4 w-4"
                     />
                     Feature on homepage
+                  </label>
+
+                  <label className="flex items-center gap-3 text-charcoal cursor-pointer" style={labelStyle}>
+                    <input
+                      type="checkbox"
+                      checked={item.exposureEligible}
+                      onChange={(e) =>
+                        updateItem(item.localId, { exposureEligible: e.target.checked })
+                      }
+                      disabled={item.status === "uploading" || item.status === "done"}
+                      className="h-4 w-4"
+                    />
+                    Eligible for Exposure
                   </label>
 
                   <p className="text-sm" style={labelStyle}>

--- a/infra/photo-upload-lambdas/src/init.js
+++ b/infra/photo-upload-lambdas/src/init.js
@@ -3,7 +3,8 @@
  *
  * Validates the session token, then returns a presigned S3 PUT URL the browser
  * uses to upload the original photo directly to the uploads bucket. Title,
- * caption, and featured flag travel as object metadata for the process Lambda.
+ * caption, featured, and exposureEligible travel as object metadata for the
+ * process Lambda.
  */
 
 const crypto = require('crypto');
@@ -36,7 +37,7 @@ exports.handler = async (event) => {
     return json(400, { message: 'Invalid request body' });
   }
 
-  const { token, filename, contentType, title, caption, featured } = body;
+  const { token, filename, contentType, title, caption, featured, exposureEligible } = body;
 
   const secret = await getSecret();
   if (!verify(secret.hmac, token)) {
@@ -53,6 +54,7 @@ exports.handler = async (event) => {
     title: Buffer.from(String(title || ''), 'utf8').toString('base64'),
     caption: Buffer.from(String(caption || ''), 'utf8').toString('base64'),
     featured: featured ? 'true' : 'false',
+    'exposure-eligible': exposureEligible ? 'true' : 'false',
     'orig-filename': safeName(filename),
   };
 
@@ -69,6 +71,7 @@ exports.handler = async (event) => {
       'x-amz-meta-title',
       'x-amz-meta-caption',
       'x-amz-meta-featured',
+      'x-amz-meta-exposure-eligible',
       'x-amz-meta-orig-filename',
     ]),
     signableHeaders: new Set(['content-type']),
@@ -79,6 +82,7 @@ exports.handler = async (event) => {
     'x-amz-meta-title': metadata.title,
     'x-amz-meta-caption': metadata.caption,
     'x-amz-meta-featured': metadata.featured,
+    'x-amz-meta-exposure-eligible': metadata['exposure-eligible'],
     'x-amz-meta-orig-filename': metadata['orig-filename'],
   };
 

--- a/infra/photo-upload-lambdas/src/lib/photo-defaults.js
+++ b/infra/photo-upload-lambdas/src/lib/photo-defaults.js
@@ -35,6 +35,7 @@ function buildNewPhoto({
   title,
   caption,
   featured,
+  exposureEligible = false,
   folderName,
   coverImageKey,
   originalKey,
@@ -67,7 +68,7 @@ function buildNewPhoto({
     longitude: null,
     publicLatitude: null,
     publicLongitude: null,
-    exposureEligible: false,
+    exposureEligible: !!exposureEligible,
     exposureSentAt: null,
     exposureIssueNumber: null,
   };

--- a/infra/photo-upload-lambdas/src/process.js
+++ b/infra/photo-upload-lambdas/src/process.js
@@ -72,6 +72,7 @@ async function processObject(bucket, key) {
     ? Buffer.from(metadata.caption, 'base64').toString('utf8')
     : '';
   const featured = metadata.featured === 'true';
+  const exposureEligible = metadata['exposure-eligible'] === 'true';
 
   const ext = (path.extname(origFilename) || '.jpg').toLowerCase();
   const photoFilename = `photo${ext}`;
@@ -130,6 +131,7 @@ async function processObject(bucket, key) {
     title,
     caption,
     featured,
+    exposureEligible,
     folderName: folder,
     coverImageKey: `images/posts/${folder}/${photoFilename}`,
     originalKey: `images/originals/posts/${folder}/${photoFilename}`,

--- a/lib/photos-api.ts
+++ b/lib/photos-api.ts
@@ -90,6 +90,7 @@ export type UploadUrlInput = {
   title?: string;
   caption?: string;
   featured?: boolean;
+  exposureEligible?: boolean;
 };
 
 export type UploadUrlResult = {
@@ -109,6 +110,7 @@ export async function getUploadUrl(input: UploadUrlInput): Promise<UploadUrlResu
       title: input.title ?? "",
       caption: input.caption ?? "",
       featured: !!input.featured,
+      exposureEligible: !!input.exposureEligible,
     }),
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Exposure eligibility was only on the **Edit** tab. The multi-photo **Upload** form already had “Feature on homepage”, so this adds matching **Eligible for Exposure** per file.

## Changes
- UI checkbox on each upload item
- `getUploadUrl` passes `exposureEligible`
- `init` → S3 metadata `exposure-eligible`
- `process` → `buildNewPhoto({ exposureEligible })`

## Note
Until this merges (and photo-upload Lambdas refresh), you can still mark existing photos on **`/upload` → Edit** tab.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa8df-a93c-70c7-a8ab-3c7b83066caf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa8df-a93c-70c7-a8ab-3c7b83066caf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

