### PR TITLE
fix(exposures): treat null exposureSentAt as unsent

### DIFF
--- a/infra/photo-upload-lambdas/src/lib/photo-defaults.js
+++ b/infra/photo-upload-lambdas/src/lib/photo-defaults.js
@@ -69,8 +69,9 @@ function buildNewPhoto({
     publicLatitude: null,
     publicLongitude: null,
     exposureEligible: !!exposureEligible,
-    exposureSentAt: null,
-    exposureIssueNumber: null,
+    // Omit exposureSentAt / exposureIssueNumber until a production send stamps
+    // them. Writing null stores DynamoDB NULL, which breaks attribute_not_exists
+    // filters used by the Sunday orchestrator.
   };
 }
 

--- a/infra/photo-upload-lambdas/src/lib/photos-db.js
+++ b/infra/photo-upload-lambdas/src/lib/photos-db.js
@@ -187,6 +187,10 @@ async function getFeaturedPhoto() {
 /**
  * Public photos eligible for Exposure and not yet sent.
  * Paginates the newest-first GSI (personal-scale catalog).
+ *
+ * Note: buildNewPhoto historically wrote exposureSentAt: null. DynamoDB NULL
+ * still "exists", so attribute_not_exists alone misses those rows — treat null
+ * as unsent as well.
  */
 async function listExposureCandidates({ maxItems = 100 } = {}) {
   const out = [];
@@ -203,9 +207,10 @@ async function listExposureCandidates({ maxItems = 100 } = {}) {
           ':pk': 'PHOTO',
           ':false': false,
           ':true': true,
+          ':null': null,
         },
         FilterExpression:
-          'draft = :false AND exposureEligible = :true AND attribute_not_exists(exposureSentAt)',
+          'draft = :false AND exposureEligible = :true AND (attribute_not_exists(exposureSentAt) OR exposureSentAt = :null)',
         ScanIndexForward: false,
         Limit: 50,
         ExclusiveStartKey,
@@ -237,8 +242,10 @@ async function stampExposureSent(id, { sentAt, issueNumber }) {
         ':s': sentAt,
         ':n': Number(issueNumber),
         ':u': nowIso(),
+        ':null': null,
       },
-      ConditionExpression: 'attribute_exists(id) AND attribute_not_exists(exposureSentAt)',
+      ConditionExpression:
+        'attribute_exists(id) AND (attribute_not_exists(exposureSentAt) OR exposureSentAt = :null)',
       ReturnValues: 'ALL_NEW',
     }),
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sunday Exposure ran empty even with an eligible, unsent photo.

**Cause:** `buildNewPhoto` wrote `exposureSentAt: null`. In DynamoDB a `NULL` attribute still *exists*, so the candidate filter `attribute_not_exists(exposureSentAt)` excluded every photo created that way (including ones marked Eligible in the UI).

## Fix
- Candidate query / stamp condition: treat missing **or** null `exposureSentAt` as unsent
- Stop writing null sent-at fields on new photos

## After merge
1. Photo-upload deploy refreshes Lambda code (workflow always updates code now)
2. Delete today’s NY lock so a re-run is allowed:
   ```bash
   AWS_PROFILE=www aws dynamodb delete-item \
     --table-name micahwalter-exposure-counter \
     --key '{"pk":{"S":"LOCK#'$(TZ=America/New_York date +%F)'"}}' \
     --region us-east-1
   ```
3. Invoke orchestrator (or wait for next Sunday):
   ```bash
   AWS_PROFILE=www aws lambda invoke \
     --function-name photo-upload-exposure-orchestrator \
     --cli-binary-format raw-in-base64-out \
     --payload '{}' \
     --no-cli-pager /tmp/exposure-out.json && cat /tmp/exposure-out.json
   ```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa8df-a93c-70c7-a8ab-3c7b83066caf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa8df-a93c-70c7-a8ab-3c7b83066caf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

