### PR TITLE
feat(exposures): project intro and newsletter signup link (#138)

### DIFF
--- a/app/exposures/[n]/page.tsx
+++ b/app/exposures/[n]/page.tsx
@@ -1,4 +1,6 @@
+import Link from "next/link";
 import ExposureDetail from "@/components/ExposureDetail";
+import ExposuresIntro from "@/components/ExposuresIntro";
 import type { Metadata } from "next";
 
 interface ExposurePageProps {
@@ -12,10 +14,23 @@ export function generateStaticParams() {
 
 export const metadata: Metadata = {
   title: "Exposure - Micah Walter",
-  description: "A photograph from the Exposure series.",
+  description:
+    "A photograph from the Exposure series — one photo and a few words, sent most Sundays.",
 };
 
 export default async function ExposureIssuePage({ params }: ExposurePageProps) {
   const { n } = await params;
-  return <ExposureDetail nHint={n} />;
+  return (
+    <div className="min-h-screen">
+      <header className="max-w-wide mx-auto px-6 pt-12 pb-6 border-b border-gray/20">
+        <p className="font-serif text-2xl text-charcoal mb-3">
+          <Link href="/exposures" className="hover:text-accent transition-colors no-underline">
+            Exposures
+          </Link>
+        </p>
+        <ExposuresIntro />
+      </header>
+      <ExposureDetail nHint={n} />
+    </div>
+  );
 }

--- a/app/exposures/page.tsx
+++ b/app/exposures/page.tsx
@@ -1,12 +1,15 @@
 import ExposuresGrid from "@/components/ExposuresGrid";
+import ExposuresIntro from "@/components/ExposuresIntro";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Exposures - Micah Walter",
-  description: "A periodic photo newsletter — one photograph at a time.",
+  description:
+    "A periodic photo newsletter — one photograph and a few words, sent most Sundays. Subscribe for the next issue.",
   openGraph: {
     title: "Exposures - Micah Walter",
-    description: "A periodic photo newsletter — one photograph at a time.",
+    description:
+      "A periodic photo newsletter — one photograph and a few words, sent most Sundays.",
   },
 };
 
@@ -17,9 +20,7 @@ export default function ExposuresPage() {
         <h1 className="font-serif font-semibold text-4xl md:text-5xl mb-4 text-charcoal">
           Exposures
         </h1>
-        <p className="text-lg text-gray max-w-reading">
-          One photograph and a few words, sent on Sundays. Archive of past issues.
-        </p>
+        <ExposuresIntro />
       </header>
 
       <ExposuresGrid />

--- a/components/ExposuresIntro.tsx
+++ b/components/ExposuresIntro.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+/**
+ * Shared project blurb for /exposures and /exposures/[n].
+ */
+export default function ExposuresIntro({ className = "" }: { className?: string }) {
+  return (
+    <p className={`text-lg text-gray max-w-reading leading-relaxed ${className}`.trim()}>
+      Exposure is a periodic photo newsletter — one photograph and a few words,
+      sent most Sundays.{" "}
+      <Link
+        href="/newsletter"
+        className="text-charcoal underline underline-offset-2 hover:text-accent transition-colors"
+      >
+        Subscribe
+      </Link>{" "}
+      to get the next one by email.
+    </p>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #138.

Adds a short Exposure project description and a **Subscribe** link to `/newsletter` on:

- `/exposures`
- `/exposures/[n]`

Shared via `components/ExposuresIntro.tsx`.

## Copy

> Exposure is a periodic photo newsletter — one photograph and a few words, sent most Sundays. [Subscribe](/newsletter) to get the next one by email.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa8df-a93c-70c7-a8ab-3c7b83066caf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa8df-a93c-70c7-a8ab-3c7b83066caf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

