### PR TITLE
feat(nav): Exposures in menu and photos page link

### DIFF
--- a/app/photos/page.tsx
+++ b/app/photos/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import PhotosGrid from "@/components/PhotosGrid";
 import type { Metadata } from "next";
 
@@ -17,8 +18,16 @@ export default function PhotosPage() {
         <h1 className="font-serif font-semibold text-4xl md:text-5xl mb-4 text-charcoal">
           Photos
         </h1>
-        <p className="text-lg text-gray max-w-reading">
-          A collection of moments captured through the lens. Each photo tells a story.
+        <p className="text-lg text-gray max-w-reading leading-relaxed">
+          A collection of moments captured through the lens. Each photo tells a
+          story. Some also appear in{" "}
+          <Link
+            href="/exposures"
+            className="text-charcoal underline underline-offset-2 hover:text-accent transition-colors"
+          >
+            Exposure
+          </Link>
+          , a periodic photo newsletter sent most Sundays.
         </p>
       </header>
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -20,6 +20,10 @@ export default function Footer() {
               Newsletter
             </a>
             {" · "}
+            <a href="/exposures" className="hover:text-charcoal transition-colors no-underline">
+              Exposures
+            </a>
+            {" · "}
             <a href="/emails" className="hover:text-charcoal transition-colors no-underline">
               Email Archive
             </a>

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -67,6 +67,14 @@ export default function MobileMenu({ isOpen, onClose, onSearchOpen }: MobileMenu
             </Link>
 
             <Link
+              href="/exposures"
+              onClick={onClose}
+              className="block px-4 py-3 text-lg text-charcoal no-underline hover:bg-charcoal/5 rounded-lg transition-colors"
+            >
+              Exposures
+            </Link>
+
+            <Link
               href="/sketches"
               onClick={onClose}
               className="block px-4 py-3 text-lg text-charcoal no-underline hover:bg-charcoal/5 rounded-lg transition-colors"

--- a/lib/fathom-url.ts
+++ b/lib/fathom-url.ts
@@ -9,6 +9,7 @@ const RESERVED_SEGMENTS = new Set([
   "about",
   "colophon",
   "emails",
+  "exposures",
   "galleries",
   "micro",
   "newsletter",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Related to #138.

- Add **Exposures** to the mobile site nav (after Photos)
- Add **Exposures** to the footer links
- On `/photos`, mention Exposure with a link to `/exposures`
- Include `exposures` in Fathom reserved path segments

## Photos intro copy

> A collection of moments captured through the lens. Each photo tells a story. Some also appear in [Exposure](/exposures), a periodic photo newsletter sent most Sundays.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa8df-a93c-70c7-a8ab-3c7b83066caf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa8df-a93c-70c7-a8ab-3c7b83066caf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

