### PR TITLE
feat(admin): Exposure queue in photos admin

### DIFF
--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -2,34 +2,44 @@
 
 ## Project Information
 - **Project Type**: Brownfield
-- **Start Date**: 2026-07-28T13:28:13Z
-- **Current Stage**: CONSTRUCTION — Build and Test (awaiting approval)
-- **Engagement Status**: In progress — [#127](https://github.com/micahwalter/micahwalter-www/issues/127)
-- **Branch**: `cursor/exposure-newsletter-6caf`
+- **Start Date**: 2026-08-20T02:48:00Z
+- **Current Stage**: CONSTRUCTION — Code Generation / Build and Test
+- **Engagement Status**: In progress — [#141](https://github.com/micahwalter/micahwalter-www/issues/141)
+- **Branch**: `cursor/exposures-queue-admin-cb29`
+
+## Workspace State
+- **Existing Code**: Yes
+- **Reverse Engineering Needed**: No (skip; #127 Exposure artifacts + current code)
+- **Workspace Root**: `/workspace`
 
 ## Extension Configuration
 | Extension | Enabled | Decided At |
 |-----------|---------|------------|
-| Security Baseline | No | Requirements Analysis |
-| Resiliency Baseline | No | Requirements Analysis |
-| Property-Based Testing | No | Requirements Analysis |
+| Security Baseline | No | Prior engagement; carried forward |
+| Resiliency Baseline | No | Prior engagement; carried forward |
+| Property-Based Testing | No | Prior engagement; carried forward |
 
 ## Stage Progress
 
 ### 🔵 INCEPTION PHASE
-- [x] Complete for #127 (User Stories skipped)
+- [x] Workspace Detection
+- [x] Reverse Engineering — SKIP
+- [x] Requirements Analysis (`issue-141-requirements.md`)
+- [x] User Stories (minimal)
+- [x] Workflow Planning
+- [x] Application Design — SKIP (existing component boundaries)
+- [x] Units Generation — SKIP (single unit)
 
 ### 🟢 CONSTRUCTION PHASE
+- [x] Functional / NFR / Infra Design — SKIP
 - [x] U1 Code Generation
-- [x] U2 Code Generation
-- [x] U3 Code Generation
-- [x] Build and Test instructions + local `tsc` / `npm run build` (awaiting approval)
+- [ ] Build and Test
 
 ### 🟡 OPERATIONS PHASE
 - [ ] Operations — PLACEHOLDER
 
 ## Current Status
 - **Lifecycle Phase**: CONSTRUCTION
-- **Current Stage**: Build and Test Complete
-- **Next Stage**: Operations placeholder / done after approval
-- **Status**: Ready for Build and Test review
+- **Current Stage**: Build and Test
+- **Next Stage**: PR after local verification
+- **Status**: Implementing Exposure queue admin tab + GET /exposure-queue

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -3,7 +3,7 @@
 ## Project Information
 - **Project Type**: Brownfield
 - **Start Date**: 2026-08-20T02:48:00Z
-- **Current Stage**: CONSTRUCTION — Code Generation / Build and Test
+- **Current Stage**: CONSTRUCTION — Build and Test complete
 - **Engagement Status**: In progress — [#141](https://github.com/micahwalter/micahwalter-www/issues/141)
 - **Branch**: `cursor/exposures-queue-admin-cb29`
 
@@ -33,13 +33,13 @@
 ### 🟢 CONSTRUCTION PHASE
 - [x] Functional / NFR / Infra Design — SKIP
 - [x] U1 Code Generation
-- [ ] Build and Test
+- [x] Build and Test
 
 ### 🟡 OPERATIONS PHASE
 - [ ] Operations — PLACEHOLDER
 
 ## Current Status
 - **Lifecycle Phase**: CONSTRUCTION
-- **Current Stage**: Build and Test
-- **Next Stage**: PR after local verification
-- **Status**: Implementing Exposure queue admin tab + GET /exposure-queue
+- **Current Stage**: Build and Test complete
+- **Next Stage**: Review / merge PR
+- **Status**: Implementation complete; draft PR opened

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -1709,3 +1709,19 @@
 **Context**: Publish — push + create PR
 
 ---
+
+## Issue #141 — Initial User Request / Workspace Detection
+**Timestamp**: 2026-08-20T02:48:00Z
+**User Input**: "Lets work on this issue https://github.com/micahwalter/micahwalter-www/issues/141"
+**AI Response**: New engagement on brownfield Next.js blog. Existing aidlc-state was for #127 (complete). Issue #141 asks for an admin view of the current Exposures queue and optionally already-sent issues. Reverse engineering skipped (Exposure subsystem from #127 is current). Extensions remain disabled. Proceeding through inception artifacts and implementation as a cloud agent (no interactive approval gates).
+**Context**: INCEPTION — Workspace Detection complete; brownfield; next = Requirements for #141
+
+---
+
+## Issue #141 — Requirements, Stories, Workflow Planning
+**Timestamp**: 2026-08-20T02:55:00Z
+**User Input**: "Lets work on this issue https://github.com/micahwalter/micahwalter-www/issues/141"
+**AI Response**: Documented FR-1 upcoming pool, FR-2 sent list, FR-3 authenticated GET /exposure-queue, FR-4 primary+secondary routes. User stories US-1/US-2/US-3. Skipped application design and units generation (single unit within photos-api + /upload). Execution plan in issue-141-execution-plan.md.
+**Context**: INCEPTION complete; CONSTRUCTION Code Generation begins
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -1725,3 +1725,11 @@
 **Context**: INCEPTION complete; CONSTRUCTION Code Generation begins
 
 ---
+
+## Issue #141 — Code Generation and Build and Test
+**Timestamp**: 2026-08-20T03:05:00Z
+**User Input**: "Lets work on this issue https://github.com/micahwalter/micahwalter-www/issues/141"
+**AI Response**: Implemented GET /photos/exposure-queue (auth) and Exposures admin tab (upcoming pool + sent archive). Lambda route tests 12/12 pass. npm run build succeeded with /upload in the route table. Local UI walkthrough confirmed Exposures tab copy; live pool/sent data requires deployed API + passcode. Draft PR opened.
+**Context**: CONSTRUCTION complete for #141
+
+---

--- a/aidlc-docs/construction/build-and-test/issue-141-build-and-test-summary.md
+++ b/aidlc-docs/construction/build-and-test/issue-141-build-and-test-summary.md
@@ -1,0 +1,33 @@
+# Build and Test — Issue #141
+
+## Unit tests
+
+From `infra/photo-upload-lambdas`:
+
+```bash
+node --test src/lib/photo-api-routes.test.js src/lib/exif.test.js
+```
+
+Expected: 12 pass (route matching for `GET /exposure-queue` plus existing EXIF tests).
+
+## Site build
+
+```bash
+npx tsc --noEmit
+npm run build
+```
+
+`/upload` must appear in the route table. `prebuild` may warn on Mastodon fetch; that is non-blocking.
+
+## Manual (owner)
+
+1. After photo-upload stack deploy (template + Lambda code), unlock `/upload`.
+2. Open the **Exposures** tab.
+3. Upcoming pool should match photos marked Eligible that have not been sent.
+4. Already sent should match `/exposures` archive, newest first.
+5. A pooled row should open Edit (`/upload?edit={id}`).
+6. Unauthenticated `GET https://api.micahwalter.com/photos/exposure-queue` returns 401.
+
+## Deploy note
+
+Merging to `main` runs `photo-upload-deploy.yml` (and secondary) because `infra/photo-upload.yml` and `infra/photo-upload-lambdas/**` changed. The new HTTP route exists only after that CloudFormation deploy.

--- a/aidlc-docs/construction/plans/issue-141-code-generation-plan.md
+++ b/aidlc-docs/construction/plans/issue-141-code-generation-plan.md
@@ -1,0 +1,9 @@
+# Code Generation Plan — Issue #141 U1 Exposure queue admin
+
+- [x] Add `isExposureQueueRoute` helper + unit tests
+- [x] Handle `GET /exposure-queue` in `photos-api.js` (auth, `listExposureCandidates`, public DTOs)
+- [x] Reserve `exposure-queue` so `GET /{id}` cannot claim it
+- [x] Add API Gateway route on primary and secondary templates; primary stage `DependsOn`
+- [x] Add `getExposureQueue` in `lib/photos-api.ts`
+- [x] Add `ExposuresAdminPanel` and Exposures tab in `UploadHub`
+- [ ] Run Lambda unit tests and `npm run build`

--- a/aidlc-docs/construction/plans/issue-141-code-generation-plan.md
+++ b/aidlc-docs/construction/plans/issue-141-code-generation-plan.md
@@ -6,4 +6,4 @@
 - [x] Add API Gateway route on primary and secondary templates; primary stage `DependsOn`
 - [x] Add `getExposureQueue` in `lib/photos-api.ts`
 - [x] Add `ExposuresAdminPanel` and Exposures tab in `UploadHub`
-- [ ] Run Lambda unit tests and `npm run build`
+- [x] Run Lambda unit tests and `npm run build`

--- a/aidlc-docs/inception/plans/issue-141-execution-plan.md
+++ b/aidlc-docs/inception/plans/issue-141-execution-plan.md
@@ -1,0 +1,73 @@
+# Execution Plan — Issue #141 Exposure queue in admin
+
+## Detailed Analysis Summary
+
+### Transformation Scope (Brownfield)
+
+- **Transformation Type**: Single-feature enhancement across existing photo admin UI and photos HTTP API
+- **Primary Changes**: Authenticated `GET /exposure-queue`; Exposures tab on `/upload`
+- **Related Components**: `photos-api` Lambda, `listExposureCandidates`, public exposures list client, `UploadHub`
+
+### Change Impact Assessment
+
+- **User-facing changes**: Yes — owner admin only
+- **Structural changes**: No new stacks or tables
+- **Data model changes**: None
+- **API changes**: New authenticated GET on photos API (primary + secondary)
+- **NFR impact**: Same auth/CORS as other admin routes
+
+### Risk Assessment
+
+- **Risk Level**: Low
+- **Rollback Complexity**: Low (remove route + tab)
+- **Testing Complexity**: Low (route matcher unit tests, `tsc` / `npm run build`; live tab needs passcode + deployed API)
+
+## Stage decisions
+
+| Stage | Decision | Why |
+|-------|----------|-----|
+| Reverse Engineering | Skip | #127 artifacts + current Exposure code are sufficient |
+| Requirements Analysis | Execute (standard) | Issue is clear; document FR |
+| User Stories | Execute (minimal) | Owner-facing admin UX |
+| Workflow Planning | Execute | This plan |
+| Application Design | Skip | Within existing photos-api + `/upload` boundaries |
+| Units Generation | Skip | Single unit of work |
+| Functional / NFR / Infra Design | Skip | No new business rules, stack, or NFR surface |
+| Code Generation | Execute | API + UI |
+| Build and Test | Execute | Unit tests + production Next build |
+
+## Workflow Visualization
+
+```mermaid
+flowchart TD
+    Start(["Issue 141"])
+    WD["Workspace Detection"]
+    RA["Requirements"]
+    US["User Stories"]
+    WP["Workflow Planning"]
+    CG["Code Generation"]
+    BT["Build and Test"]
+    Done(["PR"])
+
+    Start --> WD
+    WD --> RA
+    RA --> US
+    US --> WP
+    WP --> CG
+    CG --> BT
+    BT --> Done
+```
+
+### Text alternative
+
+1. Workspace Detection (complete)
+2. Requirements Analysis (complete)
+3. User Stories (minimal, complete)
+4. Workflow Planning (this document)
+5. Code Generation (API route + admin tab)
+6. Build and Test (unit tests + `npm run build`)
+7. Draft PR referencing Closes #141
+
+## Unit of work
+
+**U1 — Exposure queue admin**: `GET /exposure-queue` (auth) on photos-api; CloudFormation routes on primary and secondary; `getExposureQueue` client; Exposures tab listing upcoming pool + sent archive.

--- a/aidlc-docs/inception/plans/issue-141-user-stories-assessment.md
+++ b/aidlc-docs/inception/plans/issue-141-user-stories-assessment.md
@@ -1,0 +1,7 @@
+# User Stories Assessment — Issue #141
+
+**Execute**: Yes (medium priority, user-facing owner workflow)
+
+**Rationale**: New admin surface for an existing owner workflow (Exposure eligibility and weekly send). One persona (site owner). Stories stay brief.
+
+**Skip full persona rewrite**: Reuse owner persona from prior `/upload` work.

--- a/aidlc-docs/inception/requirements/issue-141-requirements.md
+++ b/aidlc-docs/inception/requirements/issue-141-requirements.md
@@ -1,0 +1,65 @@
+# Requirements — Issue #141 Exposure queue in admin
+
+| Field | Value |
+|-------|--------|
+| **Issue** | [#141](https://github.com/micahwalter/micahwalter-www/issues/141) — Create a way for me to see my current Exposures queue |
+| **User request** | Somewhere in the admin panel, see what is coming up in the Exposures queue, and maybe what has already been sent |
+| **Request type** | Enhancement (owner admin UI + authenticated read API) |
+| **Depth** | Standard |
+| **Scope** | Photos admin (`/upload`) + photo-upload photos API; reuse public Exposures archive for sent issues |
+
+## Intent analysis
+
+- **Clarity**: Clear enough to implement. “Queue” in production is an unordered **pool** of public, eligible, unsent photos; Sunday’s orchestrator picks one at random.
+- **Complexity**: Simple/moderate — existing `listExposureCandidates` + public `listExposures` cover the data; admin lacks a dedicated view.
+- **Brownfield**: Yes. Reverse engineering for Exposure exists from #127; no full RE rerun.
+
+## Functional requirements
+
+### FR-1 — Upcoming pool in admin
+
+1. After unlocking `/upload`, an **Exposures** tab shows every photo the Sunday orchestrator would consider: public (`draft = false`), `exposureEligible = true`, and not yet stamped (`exposureSentAt` missing or null).
+2. Each row shows enough to recognize the photo (thumbnail, title, id) and a way to open it in the existing Edit tab.
+3. Copy must not imply FIFO order. State that Sunday 09:00 America/New_York picks **one at random** from this pool.
+4. Empty pool: explain that nothing will send until photos are marked Eligible for Exposure on Edit (or Upload).
+
+### FR-2 — Already sent
+
+1. The same tab lists recent production Exposures (issue number, title, sent date), newest first.
+2. Link to the public archive page `/exposures/{n}` and to Edit for the photo id when present.
+3. Empty sent list is allowed (no issues yet).
+
+### FR-3 — Auth and API
+
+1. Upcoming pool is owner-only: `GET /photos/exposure-queue` requires the same Bearer session as other admin photo routes.
+2. Unauthenticated callers receive 401. The handler must not treat `exposure-queue` as a photo id.
+3. Sent issues may use the existing public Exposures list API (no new owner fields required).
+
+### FR-4 — Failover
+
+1. Primary `infra/photo-upload.yml` and secondary `infra/photo-upload-secondary.yml` both expose `GET /exposure-queue` so failover still serves the admin read.
+
+## Non-functional
+
+- Same CORS / passcode session as `/upload` (localhost + production site origin).
+- Personal-scale catalog: reuse `listExposureCandidates` cap (up to 200).
+- No change to Sunday send behavior, eligibility flags, or public archive pages.
+
+## Out of scope
+
+- Reordering the pool or forcing next Sunday’s pick
+- Showing draft-eligible photos that are not in the Sunday pool
+- Subscriber send receipts / per-address status
+- Changing random selection to FIFO
+
+## Acceptance
+
+- [ ] Unlocked admin has an Exposures tab
+- [ ] Tab lists current eligible unsent photos (the Sunday pool)
+- [ ] Tab lists already-sent Exposure issues
+- [ ] Copy makes random weekly pick explicit
+- [ ] Unauthenticated `GET /exposure-queue` is 401
+
+## Extensions
+
+Security / resiliency / property-based testing remain **disabled** (project-level decision from prior engagements). Auth for the new route follows the existing photos admin pattern.

--- a/aidlc-docs/inception/user-stories/issue-141-stories.md
+++ b/aidlc-docs/inception/user-stories/issue-141-stories.md
@@ -1,0 +1,33 @@
+# User Stories — Issue #141 Exposure queue in admin
+
+## Persona
+
+**Owner (Micah)** — authenticates to `/upload` with the photo passcode. Marks photos eligible for Exposure and wants to know what Sunday might send, and what already went out.
+
+## US-1 — See the upcoming pool
+
+As the owner, I want to open an Exposures section in photos admin so I can see which photos are in the Sunday pool without paging through Edit.
+
+**Acceptance**
+
+- Tab is visible after unlock
+- List matches orchestrator candidates (public, eligible, unsent)
+- Empty state tells me to mark photos eligible
+- Copy says Sunday picks one at random at 9:00 AM Eastern
+
+## US-2 — Jump to edit
+
+As the owner, I want to open a pooled photo in Edit so I can un-mark eligibility or send a test.
+
+**Acceptance**
+
+- Control navigates to the existing Edit flow for that photo id (`/upload?edit={id}`)
+
+## US-3 — See what already sent
+
+As the owner, I want to see recent Exposure issues on the same tab so I do not have to leave admin for `/exposures`.
+
+**Acceptance**
+
+- Newest-first list with issue number, title, sent date
+- Link to `/exposures/{n}`

--- a/app/upload/ExposuresAdminPanel.tsx
+++ b/app/upload/ExposuresAdminPanel.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { format } from "date-fns";
+import {
+  clearAdminToken,
+  getExposureQueue,
+  photoCoverFilename,
+  photoIdString,
+  PhotoApiError,
+  type PublicPhoto,
+} from "@/lib/photos-api";
+import {
+  listExposures,
+  exposureCoverFilename,
+  ExposuresApiError,
+  type PublicExposure,
+} from "@/lib/exposures-api";
+import { CoverImage } from "@/components/ResponsiveImage";
+
+const labelStyle = { fontFamily: "system-ui, -apple-system, sans-serif" };
+
+type ExposuresAdminPanelProps = {
+  token: string;
+  onSessionExpired: () => void;
+};
+
+export default function ExposuresAdminPanel({
+  token,
+  onSessionExpired,
+}: ExposuresAdminPanelProps) {
+  const router = useRouter();
+  const [upcoming, setUpcoming] = useState<PublicPhoto[]>([]);
+  const [upcomingLoading, setUpcomingLoading] = useState(true);
+  const [upcomingError, setUpcomingError] = useState("");
+
+  const [sent, setSent] = useState<PublicExposure[]>([]);
+  const [sentCursor, setSentCursor] = useState<string | null>(null);
+  const [sentLoading, setSentLoading] = useState(true);
+  const [sentError, setSentError] = useState("");
+
+  const loadUpcoming = useCallback(async () => {
+    setUpcomingLoading(true);
+    setUpcomingError("");
+    try {
+      const page = await getExposureQueue(token);
+      setUpcoming(page.upcoming);
+    } catch (err) {
+      if (err instanceof PhotoApiError && err.status === 401) {
+        clearAdminToken();
+        onSessionExpired();
+      }
+      setUpcomingError(
+        err instanceof PhotoApiError ? err.message : "Could not load the Exposure queue.",
+      );
+    } finally {
+      setUpcomingLoading(false);
+    }
+  }, [token, onSessionExpired]);
+
+  const loadSent = useCallback(async (append = false, nextCursor?: string | null) => {
+    if (!append) setSentLoading(true);
+    setSentError("");
+    try {
+      const page = await listExposures({
+        limit: 12,
+        cursor: append ? nextCursor : null,
+      });
+      setSent((prev) => (append ? [...prev, ...page.items] : page.items));
+      setSentCursor(page.cursor);
+    } catch (err) {
+      setSentError(
+        err instanceof ExposuresApiError ? err.message : "Could not load sent Exposures.",
+      );
+    } finally {
+      setSentLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadUpcoming();
+  }, [loadUpcoming]);
+
+  useEffect(() => {
+    loadSent(false);
+  }, [loadSent]);
+
+  function openEdit(id: string) {
+    router.push(`/upload?edit=${encodeURIComponent(id)}`);
+  }
+
+  const weeks = upcoming.length;
+
+  return (
+    <div className="space-y-10 max-w-xl">
+      <section>
+        <h2 className="font-serif text-xl text-charcoal mb-2">Upcoming pool</h2>
+        <p className="text-sm text-gray mb-4" style={labelStyle}>
+          These photos are eligible and not yet sent. Each Sunday at 9:00 AM Eastern,
+          one is chosen at random — this is not a fixed order.
+          {weeks > 0 ? ` About ${weeks} week${weeks === 1 ? "" : "s"} of inventory.` : ""}
+        </p>
+
+        {upcomingLoading && (
+          <p className="text-sm text-gray" style={labelStyle}>
+            Loading…
+          </p>
+        )}
+        {upcomingError && (
+          <p className="text-sm text-red-700" style={labelStyle}>
+            {upcomingError}{" "}
+            <button type="button" className="underline" onClick={loadUpcoming}>
+              Retry
+            </button>
+          </p>
+        )}
+        {!upcomingLoading && !upcomingError && upcoming.length === 0 && (
+          <p className="text-sm text-gray" style={labelStyle}>
+            Nothing in the pool. Mark photos Eligible for Exposure on the Edit tab
+            (or when uploading). Sunday will email you if the pool is still empty.
+          </p>
+        )}
+
+        {!upcomingLoading && !upcomingError && upcoming.length > 0 && (
+          <ul className="divide-y divide-gray/20 border border-gray/20">
+            {upcoming.map((photo) => {
+              const id = photoIdString(photo);
+              return (
+                <li key={id}>
+                  <button
+                    type="button"
+                    onClick={() => openEdit(id)}
+                    className="w-full text-left px-3 py-3 flex gap-3 items-center hover:bg-charcoal/5 transition-colors"
+                    style={labelStyle}
+                  >
+                    <div className="w-14 h-14 shrink-0 overflow-hidden bg-gray/10">
+                      <CoverImage
+                        folderName={photo.folderName}
+                        filename={photoCoverFilename(photo)}
+                        alt=""
+                        className="w-full h-full object-cover"
+                        sizes="56px"
+                      />
+                    </div>
+                    <div className="min-w-0">
+                      <p className="font-serif text-charcoal truncate">{photo.title}</p>
+                      <p className="text-xs text-gray">
+                        #{id}
+                        {photo.publishedAt
+                          ? ` · ${format(new Date(photo.publishedAt), "MMM d, yyyy")}`
+                          : ""}
+                      </p>
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h2 className="font-serif text-xl text-charcoal mb-2">Already sent</h2>
+        <p className="text-sm text-gray mb-4" style={labelStyle}>
+          Production Exposure issues, newest first.
+        </p>
+
+        {sentLoading && sent.length === 0 && (
+          <p className="text-sm text-gray" style={labelStyle}>
+            Loading…
+          </p>
+        )}
+        {sentError && (
+          <p className="text-sm text-red-700" style={labelStyle}>
+            {sentError}{" "}
+            <button type="button" className="underline" onClick={() => loadSent(false)}>
+              Retry
+            </button>
+          </p>
+        )}
+        {!sentLoading && !sentError && sent.length === 0 && (
+          <p className="text-sm text-gray" style={labelStyle}>
+            No Exposures have been sent yet.
+          </p>
+        )}
+
+        {sent.length > 0 && (
+          <ul className="divide-y divide-gray/20 border border-gray/20">
+            {sent.map((exp) => (
+              <li key={exp.issueNumber} className="px-3 py-3 flex gap-3 items-center">
+                <Link
+                  href={`/exposures/${exp.issueNumber}`}
+                  className="w-14 h-14 shrink-0 overflow-hidden bg-gray/10"
+                >
+                  {exp.folderName ? (
+                    <CoverImage
+                      folderName={exp.folderName}
+                      filename={exposureCoverFilename(exp)}
+                      alt=""
+                      className="w-full h-full object-cover"
+                      sizes="56px"
+                    />
+                  ) : null}
+                </Link>
+                <div className="min-w-0 flex-1" style={labelStyle}>
+                  <p className="font-serif text-charcoal truncate">{exp.title}</p>
+                  <p className="text-xs text-gray">
+                    Exposure #{exp.issueNumber}
+                    {exp.sentAt ? ` · ${format(new Date(exp.sentAt), "MMM d, yyyy")}` : ""}
+                  </p>
+                  <p className="text-xs mt-1 space-x-3">
+                    <Link
+                      href={`/exposures/${exp.issueNumber}`}
+                      className="underline text-charcoal hover:text-accent"
+                    >
+                      Archive
+                    </Link>
+                    {exp.photoId ? (
+                      <button
+                        type="button"
+                        onClick={() => openEdit(String(exp.photoId))}
+                        className="underline text-charcoal hover:text-accent"
+                      >
+                        Edit photo
+                      </button>
+                    ) : null}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+        {sentCursor && (
+          <button
+            type="button"
+            onClick={() => loadSent(true, sentCursor)}
+            className="mt-3 text-sm text-charcoal underline hover:text-accent"
+            style={labelStyle}
+          >
+            Load more
+          </button>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/upload/UploadHub.tsx
+++ b/app/upload/UploadHub.tsx
@@ -12,10 +12,11 @@ import {
 import UploadForm from "./UploadForm";
 import PhotoEditPanel from "./PhotoEditPanel";
 import GalleryAdminPanel from "./GalleryAdminPanel";
+import ExposuresAdminPanel from "./ExposuresAdminPanel";
 
 const labelStyle = { fontFamily: "system-ui, -apple-system, sans-serif" };
 
-type Tab = "upload" | "edit" | "galleries";
+type Tab = "upload" | "edit" | "galleries" | "exposures";
 
 function UploadHubInner() {
   const formId = useId();
@@ -147,6 +148,20 @@ function UploadHubInner() {
           >
             Galleries
           </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "exposures"}
+            onClick={() => setTab("exposures")}
+            className={`px-4 py-2 text-sm tracking-wide transition-colors ${
+              tab === "exposures"
+                ? "bg-charcoal text-cream"
+                : "text-charcoal border border-gray/30 hover:bg-charcoal/5"
+            }`}
+            style={labelStyle}
+          >
+            Exposures
+          </button>
         </div>
         <button
           type="button"
@@ -176,6 +191,9 @@ function UploadHubInner() {
       )}
       {tab === "galleries" && (
         <GalleryAdminPanel token={token} onSessionExpired={handleSessionExpired} />
+      )}
+      {tab === "exposures" && (
+        <ExposuresAdminPanel token={token} onSessionExpired={handleSessionExpired} />
       )}
     </div>
   );

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -14,8 +14,9 @@ export default function UploadPage() {
         Photos admin
       </h1>
       <p className="text-gray mb-8">
-        Upload new photos or edit title, caption, tags, and featured for existing
-        ones. Changes go through the photo API — no site rebuild required.
+        Upload new photos, edit metadata, manage galleries, or review the
+        Exposure pool and what has already been sent. Changes go through the
+        photo API — no site rebuild required.
       </p>
       <UploadHub />
     </main>

--- a/infra/photo-upload-lambdas/src/lib/photo-api-routes.js
+++ b/infra/photo-upload-lambdas/src/lib/photo-api-routes.js
@@ -1,0 +1,25 @@
+/**
+ * Route matchers for photos-api. Kept free of AWS clients so tests can require
+ * this module without DynamoDB/Secrets setup.
+ */
+
+function isExposureQueueRoute(routeKey, method, path) {
+  if (routeKey === 'GET /exposure-queue' || routeKey === 'GET /photos/exposure-queue') {
+    return true;
+  }
+  return method === 'GET' && (path === '/exposure-queue' || path === '/exposure-queue/');
+}
+
+function isReservedPhotoId(id) {
+  return (
+    !id ||
+    id === 'featured' ||
+    id === 'galleries' ||
+    id === 'exposure-queue'
+  );
+}
+
+module.exports = {
+  isExposureQueueRoute,
+  isReservedPhotoId,
+};

--- a/infra/photo-upload-lambdas/src/lib/photo-api-routes.test.js
+++ b/infra/photo-upload-lambdas/src/lib/photo-api-routes.test.js
@@ -1,0 +1,37 @@
+/**
+ * Route matching for the Exposure queue admin endpoint (issue #141).
+ * Run: node --test src/lib/photo-api-routes.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { isExposureQueueRoute, isReservedPhotoId } = require('./photo-api-routes');
+
+describe('isExposureQueueRoute', () => {
+  it('matches API Gateway route keys with and without the mapping prefix', () => {
+    assert.equal(isExposureQueueRoute('GET /exposure-queue', 'GET', '/other'), true);
+    assert.equal(isExposureQueueRoute('GET /photos/exposure-queue', 'GET', '/other'), true);
+  });
+
+  it('matches path fallbacks used when routeKey is empty', () => {
+    assert.equal(isExposureQueueRoute('', 'GET', '/exposure-queue'), true);
+    assert.equal(isExposureQueueRoute('', 'GET', '/exposure-queue/'), true);
+  });
+
+  it('does not match photo ids or other verbs', () => {
+    assert.equal(isExposureQueueRoute('GET /{id}', 'GET', '/141'), false);
+    assert.equal(isExposureQueueRoute('', 'GET', '/141'), false);
+    assert.equal(isExposureQueueRoute('', 'POST', '/exposure-queue'), false);
+    assert.equal(isExposureQueueRoute('GET /featured', 'GET', '/featured'), false);
+  });
+});
+
+describe('isReservedPhotoId', () => {
+  it('reserves static photo-api paths so GET /{id} cannot capture them', () => {
+    assert.equal(isReservedPhotoId('exposure-queue'), true);
+    assert.equal(isReservedPhotoId('featured'), true);
+    assert.equal(isReservedPhotoId('galleries'), true);
+    assert.equal(isReservedPhotoId(''), true);
+    assert.equal(isReservedPhotoId('141'), false);
+  });
+});

--- a/infra/photo-upload-lambdas/src/photos-api.js
+++ b/infra/photo-upload-lambdas/src/photos-api.js
@@ -4,6 +4,7 @@
  *
  * Custom domain mapping key is `photos`, so public URLs are:
  *   GET/PATCH https://api.micahwalter.com/photos/...
+ *   GET https://api.micahwalter.com/photos/exposure-queue (owner session)
  *   GET/POST/PATCH https://api.micahwalter.com/photos/galleries...
  * RouteKeys below are relative to that mapping (not prefixed with /photos).
  */
@@ -15,8 +16,10 @@ const {
   updatePhoto,
   listPhotos,
   getFeaturedPhoto,
+  listExposureCandidates,
 } = require('./lib/photos-db');
 const { toPublicPhoto } = require('./lib/photo-dto');
+const { isExposureQueueRoute, isReservedPhotoId } = require('./lib/photo-api-routes');
 const { buildExposureEmail } = require('./lib/exposure-email');
 const { emitNewsletterSendRequested } = require('./lib/newsletter-events');
 const {
@@ -223,9 +226,22 @@ exports.handler = async (event) => {
     }
 
     // --- Photos ---
+    if (isExposureQueueRoute(routeKey, method, path)) {
+      try {
+        await requireAuth(event, {});
+      } catch (err) {
+        return json(401, { message: err.message });
+      }
+      const upcoming = await listExposureCandidates({ maxItems: 200 });
+      return json(200, {
+        upcoming: upcoming.map(toPublicPhoto),
+        count: upcoming.length,
+      });
+    }
+
     if (isExposureTest(routeKey, method, path)) {
       const id = photoIdFromExposureTestPath(event, path);
-      if (!id || id === 'featured' || id === 'galleries') {
+      if (isReservedPhotoId(id)) {
         return json(404, { message: 'Not found' });
       }
 
@@ -295,7 +311,7 @@ exports.handler = async (event) => {
 
     if (routeKey === 'GET /{id}' || routeKey === 'GET /photos/{id}' || (method === 'GET' && /^\/[^/]+$/.test(path))) {
       const id = event.pathParameters?.id || path.slice(1);
-      if (!id || id === 'featured' || id === 'galleries') return json(404, { message: 'Not found' });
+      if (isReservedPhotoId(id)) return json(404, { message: 'Not found' });
       const photo = await getPhoto(id);
       if (!photo || photo.draft) return json(404, { message: 'Not found' });
       return json(200, toPublicPhoto(photo));

--- a/infra/photo-upload-secondary.yml
+++ b/infra/photo-upload-secondary.yml
@@ -74,6 +74,7 @@ Resources:
       - PhotosFeaturedRoute
       - PhotosGetRoute
       - PhotosPatchRoute
+      - PhotosExposureQueueRoute
     Properties:
       ApiId: !Ref PhotoApi
       StageName: $default
@@ -262,6 +263,13 @@ Resources:
     Properties:
       ApiId: !Ref PhotoApi
       RouteKey: PATCH /{id}
+      Target: !Sub integrations/${PhotosApiIntegration}
+
+  PhotosExposureQueueRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref PhotoApi
+      RouteKey: GET /exposure-queue
       Target: !Sub integrations/${PhotosApiIntegration}
 
   # Do NOT add $default — see primary photo-upload.yml note (CORS + bare-path 500s).

--- a/infra/photo-upload.yml
+++ b/infra/photo-upload.yml
@@ -237,6 +237,7 @@ Resources:
       - PhotosGetRoute
       - PhotosPatchRoute
       - PhotosExposureTestRoute
+      - PhotosExposureQueueRoute
     Properties:
       ApiId: !Ref PhotoApi
       StageName: $default
@@ -681,6 +682,13 @@ Resources:
     Properties:
       ApiId: !Ref PhotoApi
       RouteKey: POST /{id}/exposure-test
+      Target: !Sub integrations/${PhotosApiIntegration}
+
+  PhotosExposureQueueRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref PhotoApi
+      RouteKey: GET /exposure-queue
       Target: !Sub integrations/${PhotosApiIntegration}
 
   AuthFnPermission:

--- a/lib/photos-api.ts
+++ b/lib/photos-api.ts
@@ -309,6 +309,33 @@ export async function updatePhoto(
   return res.json() as Promise<PublicPhoto>;
 }
 
+export type ExposureQueuePage = {
+  upcoming: PublicPhoto[];
+  count: number;
+};
+
+/** Owner-only Sunday Exposure pool (eligible, public, not yet sent). */
+export async function getExposureQueue(token: string): Promise<ExposureQueuePage> {
+  const res = await fetch(`${getPhotoApiBase()}/exposure-queue`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    throw new PhotoApiError(
+      res.status === 401
+        ? "Your session expired. Please enter the passcode again."
+        : "Could not load the Exposure queue.",
+      res.status,
+    );
+  }
+
+  const data = (await res.json()) as ExposureQueuePage;
+  return {
+    upcoming: data.upcoming || [],
+    count: data.count ?? (data.upcoming || []).length,
+  };
+}
+
 /** Queue a test Exposure email to AdminEmail (does not stamp or blast subscribers). */
 export async function sendExposureTest(
   id: string | number,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an **Exposures** tab on `/upload` so you can see the current Sunday pool and what has already been sent ([#141](https://github.com/micahwalter/micahwalter-www/issues/141)).

## What you get
- **Upcoming pool**: public photos marked eligible that have not been stamped yet (same set the Sunday orchestrator picks from). One photo is chosen **at random** each Sunday at 9:00 AM Eastern — the tab says so explicitly.
- **Already sent**: recent production Exposure issues (issue number, title, date) with links to `/exposures/{n}` and Edit.
- Clicking a pooled photo opens the existing Edit tab (`/upload?edit={id}`).

## API
Authenticated `GET /photos/exposure-queue` (Bearer session, same as other admin photo routes). Unauthenticated → 401. The path is reserved so `GET /{id}` cannot treat `exposure-queue` as a photo id.

CloudFormation routes are added on both primary (`infra/photo-upload.yml`) and secondary (`infra/photo-upload-secondary.yml`). Merging to `main` deploys via the existing photo-upload GitHub Actions workflows (template change → full stack deploy).

## Verification
- Lambda route tests: `node --test src/lib/photo-api-routes.test.js` (plus existing EXIF tests) — 12 pass
- `npm run build` — compiled successfully; `/upload` in the route table
- Local UI: Exposures tab, upcoming/sent headings, and Sunday random-pick copy. Live lists need the deployed API and a real passcode (this environment has neither).

[Photos admin locked passcode form](https://cursor.com/agents/bc-e95b9f77-f660-4eb3-b279-9c4bc278cb29/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphotos_admin_locked.webp)
[Unlocked admin tabs including Exposures](https://cursor.com/agents/bc-e95b9f77-f660-4eb3-b279-9c4bc278cb29/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphotos_admin_tabs_including_exposures.webp)
[Exposures tab with upcoming pool and already sent](https://cursor.com/agents/bc-e95b9f77-f660-4eb3-b279-9c4bc278cb29/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexposures_tab_upcoming_and_sent.webp)
[exposures_admin_tab_walkthrough.mp4](https://cursor.com/agents/bc-e95b9f77-f660-4eb3-b279-9c4bc278cb29/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexposures_admin_tab_walkthrough.mp4)

## Out of scope
- Forcing next Sunday’s pick or reordering the pool
- Draft-eligible photos that are not in the Sunday pool

Closes #141


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e95b9f77-f660-4eb3-b279-9c4bc278cb29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e95b9f77-f660-4eb3-b279-9c4bc278cb29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

